### PR TITLE
Troubleshooting docs 3.0.0

### DIFF
--- a/src/pages/docs/troubleshooting/NLPs/unable-to-retrieve-value.md
+++ b/src/pages/docs/troubleshooting/NLPs/unable-to-retrieve-value.md
@@ -2,7 +2,7 @@
 title: "Unable to retrieve value stored in text element"
 metadesc: "Unable to retrieve value"
 noindex: false
-order: 23.11
+order: 23.1
 page_id: "Unable to retrieve value"
 warning: false
 ---

--- a/src/pages/docs/troubleshooting/NLPs/unable-to-retrieve-value.md
+++ b/src/pages/docs/troubleshooting/NLPs/unable-to-retrieve-value.md
@@ -2,11 +2,7 @@
 title: "Unable to retrieve value stored in text element"
 metadesc: "Unable to retrieve value"
 noindex: false
-<<<<<<< HEAD
 order: 23.1
-=======
-order: 23.11
->>>>>>> f881fc48345ddad1219fcd8c882ff4259529e500
 page_id: "Unable to retrieve value"
 warning: false
 ---

--- a/src/pages/docs/troubleshooting/NLPs/unable-to-retrieve-value.md
+++ b/src/pages/docs/troubleshooting/NLPs/unable-to-retrieve-value.md
@@ -2,7 +2,7 @@
 title: "Unable to retrieve value stored in text element"
 metadesc: "Unable to retrieve value"
 noindex: false
-order: 23.10
+order: 23.11
 page_id: "Unable to retrieve value"
 warning: false
 ---

--- a/src/pages/docs/troubleshooting/agent/unable-to-create-new-testsession.md
+++ b/src/pages/docs/troubleshooting/agent/unable-to-create-new-testsession.md
@@ -2,7 +2,6 @@
 title: "Unable to create new test session due to unexpected error"
 metadesc: "Unable to create new test session due to unexpected error"
 noindex: false
-<<<<<<< HEAD
 order: 23.20
 page_id: "Unable to create new test session due to unexpected error"
 warning: false
@@ -35,10 +34,3 @@ ul.circle {
 <li>Rerun the test case.</li>
 <li>After following the above steps, if you see the same error message reach out to Testsigma support for the test logs.</li>
 </ol>
-=======
-order: 23.14
-page_id: "Unable to create new test session due to unexpected error"
-warning: false
----
-dsggs
->>>>>>> f881fc48345ddad1219fcd8c882ff4259529e500

--- a/src/pages/docs/troubleshooting/agent/unable-to-create-new-testsession.md
+++ b/src/pages/docs/troubleshooting/agent/unable-to-create-new-testsession.md
@@ -1,0 +1,9 @@
+---
+title: "Unable to create new test session due to unexpected error"
+metadesc: "Unable to create new test session due to unexpected error"
+noindex: false
+order: 23.14
+page_id: "Unable to create new test session due to unexpected error"
+warning: false
+---
+dsggs

--- a/src/pages/docs/troubleshooting/agent/unable-to-create-new-testsession.md
+++ b/src/pages/docs/troubleshooting/agent/unable-to-create-new-testsession.md
@@ -2,8 +2,35 @@
 title: "Unable to create new test session due to unexpected error"
 metadesc: "Unable to create new test session due to unexpected error"
 noindex: false
-order: 23.14
+order: 23.20
 page_id: "Unable to create new test session due to unexpected error"
 warning: false
 ---
-dsggs
+<head>
+<style>
+ul.disc {
+  list-style-type: disc;
+}
+ul.circle {
+  list-style-type: circle;
+}
+</style>
+</head>
+
+<br><p>In this article, we will take you through a series of troubleshooting steps to try and help you figure out the cause of the error <em>Unable to create a new test session due to unexpected failure- Error while creating driver</em>.</p>
+
+<h2><strong>Troubleshooting steps</strong></h2>
+<ol>
+<li>Make sure the agent and device are in an active state.
+<ul class="disc">
+<li>To know if the Testsigma agent is running, navigate to <strong>Agents</strong>. Select <strong>Active agents</strong> from the drop-down. Check if your local agent is part of the list. If not, refer to <a href="https://testsigma.com/docs/agent/troubleshooting/setup-issues/com">troubleshooting Testsigma agent issues</a>.</li>
+<li>To know if the local device is active, navigate to <strong>Agents >Testsigma agent > Devices</strong>. Under devices, you can see the device connected to the Testsigma agent. If your device is unlisted, refer to following guides : <a href="https://testsigma.com/docs/agent/connect-android-local-devices/" >Android</a> and <a href="https://testsigma.com/docs/agent/connect-ios-local-devices/" >iOS</a></li>
+</ul>
+</li>
+<li>Now execute the test case on the local device. <em>For more information, refer to <a href="https://testsigma.com/docs/runs/test-plans-on-local-devices/">executing test cases on local device</a></em>.</li>
+<li>On the dry run page under App details sections, select Use path and provide the required details. Try running the test case.</li>
+<li>If the issue persists, on the dry run page under App details sections, select Use details. Rerun the test case.</li>
+<li>If the error continues, uninstall the app on the device and reinstall it.</li> 
+<li>Rerun the test case.</li>
+<li>After following the above steps, if you see the same error message reach out to Testsigma support for the test logs.</li>
+</ol>


### PR DESCRIPTION
Created a new troubleshooting doc for https://testsigma.atlassian.net/browse/DOC-16
steps to debug the local mobile execution issues: troubleshoot "Unable to create a new Test Session due to unexpected failure(0x537). - Error while creating driver"