### PR TITLE
Updated Default Data Generators, Mailbox TDT Doc

### DIFF
--- a/src/pages/docs/test-data/data-generators/default-list.md
+++ b/src/pages/docs/test-data/data-generators/default-list.md
@@ -1,5 +1,5 @@
 ---
-title: "Default test data generators"
+title: "Default Test Data Generators"
 metadesc: "Lists out the built-in Data Generator functions available in Testsigma and describe its usage"
 noindex: false
 order: 5.32
@@ -9,10 +9,7 @@ warning: false
 
 ---
 
-To know how to use the default test data generators in your test steps, refer to [test data generator usage in test steps](https://testsigma.com/docs/test-data/types/data-generator/)
-
-If you don't find the data generator that you are looking for, create your own.For more information refer to [create test data generators using addons](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/)
-
+Testsigma offers a variety of predefined data types, including text, number, date, email, phone number, and others. You can use these data types to create test data for various field types. Refer to [test data generator usage in test steps](https://testsigma.com/docs/test-data/data-generators/default-list/) to learn how to use the default test data generators in your test steps.
 
 Given below is the list of default test data generators available in Testsigma:
 
@@ -34,31 +31,37 @@ Given below is the list of default test data generators available in Testsigma:
     <td>DomainFunction</td>
     <td>emailWithDomain</td>
     <td>Generates an email with a domain</td>
-    <td>Domain name.<br><em>For example:google.com,testsigma.com</em></td>
+    <td>Preferred Domain name.<br><em>For example: google.com, testsigma.com</em></td>
   </tr>
   <tr>
     <td>EmailFunctions</td>
     <td>username</td>
     <td>Generate a username</td>
-    <td>Length of username</td>
+    <td>Required length of username(actual names).<br><em>For example: Length - 8</em></td>
   </tr>
   <tr>
     <td>EmailFunctions</td>
     <td>randomAlphanumaricEmail</td>
     <td>Generates a random email with both numbers and letters</td>
-    <td>Length of email</td>
+    <td>Required length of email(random alphanumeric characters)</td>
   </tr>
   <tr>
     <td>EmailFunctions</td>
     <td>randomAlphaNumericEmailWithDomain</td>
     <td>Generate a random email string with both alphabet and numbers</td>
-    <td><ul><li>Length of email</li><li>Domain name</li></ul></td>
+    <td><li>Length of email before @</li><li>Preferred domain name for the email</li></td>
 </tr>
 <tr>
     <td>EmailFunctions</td>
     <td>randomEmail</td>
     <td>Generates a random email</td>
-    <td><ul><li>Length of email</li><li>Domain name</li></ul></td>
+    <td><li>Length of email before @ (Valid Names)</li><li>Preferred domain name for the email</li></td>
+</tr>
+<tr>
+    <td>EmailFunctions</td>
+    <td>randomEmail</td>
+    <td>Generates a random email</td>
+    <td>Length of email before @ (Valid Names)</td>
 </tr>
 <tr>
     <td>NameFunctions</td>
@@ -70,91 +73,103 @@ Given below is the list of default test data generators available in Testsigma:
     <td>PhoneNumberFunctions</td>
     <td>getOTP</td>
     <td>Fetch OTP from an SMS</td>
-    <td><ul><li>Regex or regular expression(a sequence of characters that specifies a search pattern in text)</li><li>Phone number</li><li>timeout in seconds</li></ul></td>
+    <td><li>Regex</li><li>Phone number</li><li>timeout in seconds</li></td>
   </tr>
   <tr>
     <td>MailBoxFunctions</td>
     <td>getEmailOTP</td>
     <td>Fetch OTP sent to the email box into a variable.</td>
-    <td><ul><li>Regex or regular expression(a sequence of characters that specifies a search pattern in text)</li><li>linked mailbox to which the OTP should be recieved</li><li>timeout in seconds</li></ul></td>
+    <td><li>Regex</li><li>Linked mailbox to which the OTP should be recieved</li><li>Timeout in seconds</li></td>
   </tr>
   <tr>
     <td>MailBoxFunctions</td>
     <td>getLinkFromContent</td>
     <td>Fetch link from a piece of content</td>
-    <td>Same as above</td>
+    <td><li>Regex</li><li>Linked Mailbox</li><li>Timeout in seconds</li></td>
   </tr>
   <tr>
     <td>MailBoxFunctions</td>
     <td>subjectVerification</td>
     <td>Verify subject of email</td>
-    <td>Same as above</td>
+    <td><li>Regex</li><li>Linked Mailbox</li><li>Timeout in seconds</li></td>
   </tr>
   <tr>
     <td>MailBoxFunctions</td>
     <td>contentVerification</td>
     <td>Verify content of email</td>
-    <td><ul><li>Regex</li><li>linked mailbox</li><li>timeout in seconds</li><li>the character string to compare</li></ul></td>
+    <td><li>Regex</li><li>Linked Mailbox</li><li>Timeout in seconds</li><li>Character String to compare</li></td>
   </tr>
- <tr>
-    <td>MailBoxFunctions</td>
+  <tr>
+    <td>MailBoxAliasFunctions</td>
     <td>generateMailBoxAlias</td>
-    <td>Generate a unique mailbox every time it is executed during a test execution.</td>
-    <td>linked mailbox</td>
+    <td>Generate a unique mailbox every time it is executed during test execution.</td>
+    <td>Select Linked Mailbox to create a new email address.</td>
   </tr>
   <tr>
-    <td>MailBoxFunctions</td>
+    <td>MailBoxAliasFunctions</td>
     <td>getEmailContent</td>
-    <td>Fetch the entire email content into a variable</td>
-    <td><ul><li>Runtimevariable</li><li>timeout in seconds</li></ul></td>
-  </tr> 
-<tr>
-    <td>MailBoxFunctions</td>
+    <td>Fetch the entire email content into a variable.</td>
+    <td><li>Runtime Variable</li><li>Timeout in seconds</li></td>
+  </tr>
+  <tr>
+    <td>MailBoxAliasFunctions</td>
     <td>getEmailSubject</td>
-    <td>Fetch the subject of the email in to a variable</td>
-    <td>Same as above</td>
-  </tr> 
+    <td>Fetch the subject of the email in to a variable.</td>
+    <td><li>Runtime Variable</li><li>Timeout in seconds</li></td>
+  </tr>
   <tr>
-    <td>MailBoxFunctions</td>
+    <td>MailBoxAliasFunctions</td>
     <td>getOTP</td>
-    <td>Fetch OTP from the email</td>
-    <td><ul><li>Regex</li><li>runtimeVariable</li><li>timeout in seconds</li></ul></td>
-  </tr> 
+    <td>Fetch OTP from the email.</td>
+    <td><li>Regex</li><li>Runtime Variable</li><li>Timeout in seconds</li></td>
+  </tr>
   <tr>
-    <td>MailBoxFunctions</td>
+    <td>MailBoxAliasFunctions</td>
     <td>urlWithText</td>
     <td>Fetch the URL that contains some required text.</td>
-    <td><ul><li>Text</li><li>runtimeVariable</li><li>timeout in seconds</li></ul></td>
-  </tr> 
+    <td><li>Text</li><li>Runtime Variable</li><li>Timeout in seconds</li></td>
+  </tr>
   <tr>
-    <td>MailBoxFunctions</td>
-    <td>urlWhichContain</td>
+    <td>MailBoxAliasFunctions</td>
+    <td>urlWhichContains</td>
     <td>Fetch the URL that contains some required parameters.</td>
-    <td><ul><li>Substring</li><li>runtimeVariable</li><li>timeout in seconds</li></ul></td>
-  </tr> 
+    <td><li>Substring</li><li>Runtime Variable</li><li>Timeout in seconds</li></td>
+  </tr>
   <tr>
-    <td>MailBoxFunctions</td>
-    <td>UrlMatchingRegex</td>
+    <td>MailBoxAliasFunctions</td>
+    <td>urlMatchingRegex</td>
     <td>Fetch the URL that contains a URL matching the required regular expression.</td>
+    <td><li>Regex</li><li>Runtime Variable</li><li>Timeout in seconds</li></td>
+  </tr>
+  <tr>
+    <td>TestDataFromProfile</td>
+    <td>getTestDataBySetName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>TestDataFromProfile</td>
+    <td>getTestDataByRowNumber</td>
+    <td></td>
     <td></td>
   </tr>
   <tr>
     <td>RandomStringFunctions</td>
     <td>randomStringFromGivenCharactersWithLength</td>
     <td>Generates a random string from the given set of characters</td>
-    <td><ul><li>Stringlength= length of the string to be generated in <kbd>integer</kbd> format</li><li> list = list of characters</li></ul></td>
+    <td><li>Stringlength - length of the string to be generated in integer format</li><li> List - List of characters</li></ul></td>
   </tr>
    <tr>
-    <td>Randomtext</td>
+    <td>CustomerFriends</td>
     <td>phrases</td>
     <td>Generates random text phrases</td>
-    <td><ul><li>Stringlength = length of the string to be generated in <kbd>integer</kbd> format </li> <li>list = list of characters</li></ul></td>
+    <td><li>Stringlength - length of the string to be generated in integer format.</li> <li>List - list of characters</li></td>
   </tr>
   <tr>
     <td>Number</td>
     <td>random number</td>
     <td>Generates a random number between a given range</td>
-    <td><ul><li>min = minimum value of range of numbers</li><li>max = maximum value of range of numbers</li></ul></td>
+    <td><li>min - minimum value of range of numbers</li><li>max - maximum value of range of numbers</li></td>
   </tr>
   <tr>
     <td>Number</td>
@@ -172,7 +187,373 @@ Given below is the list of default test data generators available in Testsigma:
     <td>Number</td>
     <td>number of digits</td>
     <td>Generates n number of digits</td>
-    <td><ul><li>number of digits</li><li>boolean value</li></ul></td>
+    <td><li>Number of digits</li><li>Boolean - True/ False</li></td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>randomNumber</td>
+    <td></td>
+    <td><li>Integer - no. of digits of generated random number</li><li>Boolean - True/ False</li></td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>randomDouble</td>
+    <td></td>
+    <td><li>Integer - Maximum Number of Decimals</li><li>Integer - Minimum value</li><li>Integer - Maximum value</li></td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>randomDouble</td>
+    <td></td>
+    <td><li>Integer - Maximum Number of Decimals</li><li>Long - Minimum value</li><li>Long - Maximum value</li></td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>digits</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>name</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>nameWithMiddle</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>fullName</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>firstName</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>lastName</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>prefix</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>suffix</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>title</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>Number</td>
+    <td>username</td>
+    <td></td>
+    <td>Integer - Number of digits</td>
+  </tr>
+  <tr>
+    <td>PhoneNumber</td>
+    <td>cellPhone</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>PhoneNumber</td>
+    <td>phoneNumber</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>domainName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>domainWord</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>domainSuffix</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>emailAddress</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>emailAddress</td>
+    <td></td>
+    <td>String - local Part</td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>safeEmailAddress</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>safeEmailAddress</td>
+    <td></td>
+    <td>String - local Part</td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>url</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>image</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>password</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Internet</td>
+    <td>uuid</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>File</td>
+    <td>mimeType</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>File</td>
+    <td>fileName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>File</td>
+    <td>fileName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>File</td>
+    <td>fileName</td>
+    <td></td>
+    <td><li>"Argument 1 ": "Argument 1 "</li><li>"Argument 1 ": "Argument 1 "</li><li>"argument2 ": "argument2 "</li><li>"argument3 ": "argument3 "</li></td>
+  </tr>
+  <tr>
+    <td>Friends</td>
+    <td>character</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Friends</td>
+    <td>location</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Friends</td>
+    <td>location</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>IdNumber</td>
+    <td>valid</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>IdNumber</td>
+    <td>invalid</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>IdNumber</td>
+    <td>ssnValid</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>IdNumber</td>
+    <td>validSvSeSsn</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>IdNumber</td>
+    <td>invalidSvSeSsn</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>streetName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>streetAddressNumber</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>streetAddress</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>streetAddress</td>
+    <td></td>
+    <td>Argument 1: Argument 1</td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>secondaryAddress</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>zipCode</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>zipCodeByState</td>
+    <td></td>
+    <td>Argument 1: Argument 1</td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>streetSuffix</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>streetPrefix</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>citySuffix</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>cityPrefix</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>city</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>cityName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>state</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>stateAbbr</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>firstName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>lastName</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>latitude</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>longitude</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>timeZone</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>country</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>countryCode</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Address</td>
+    <td>buildingNumber</td>
+    <td></td>
+    <td></td>
   </tr>
    <tr>
     <td>Address</td>
@@ -233,67 +614,86 @@ Given below is the list of default test data generators available in Testsigma:
     <td>joinSampleOfEachList</td>
     <td></td>
     <td></td>
+  </tr>
+  <tr>
+    <td>Email</td>
+    <td>mailbox</td>
+    <td></td>
+    <td></td>
   </tr> 
   <tr>
     <td>DateFunctions</td>
     <td>future</td>
     <td>Generates future date within atmost 'x' time units</td>
-    <td><ul><li>atmost = at the maximum 'x' units in integer format</li> <li>unit= unit of time like day,hours,minutes,seconds etc;</li><li>Reference dates= any date</li><li> format = format of date, example:ddmmyyy or mmddyyyy</li></ul></td>
+    <td><li>atmost = at the maximum 'x' units in integer format</li> <li>Unit - Unit of time like day,hours,minutes,seconds etc;</li><li>Reference dates - any date</li><li> Format = Format of date, example:ddmmyyy or mmddyyyy</li></td>
+  </tr>
+  <tr>
+    <td>DateFunctions</td>
+    <td>future</td>
+    <td>Generates future date within atmost 'x' time units</td>
+    <td><li>Integer - Upper limit of value to be added (any random value between 0 and this value can be used)</li><li>String - Format of Date to be generated</li></td>
   </tr>
   <tr>
     <td>DateFunctions</td>
     <td>current</td>
     <td>Generates current date within atmost 'x' units of time</td>
-    <td><ul><li>format:dd-mm-yyyy</li><li>atmost = at the maximum 'x' units in <kbd>integer</kbd> format</li><li>unit=unit of time like day/hours/minute etc.</li></ul></td>
+    <td><li>Format : dd-mm-yyyy</li><li>atmost = at the maximum 'x' units in integer format</li><li>Unit - unit of time like day/hours/minute etc.</li></td>
   </tr> 
-<tr>
+  <tr>
     <td>DateFunctions</td>
     <td>past</td>
     <td>Generates past date within atmost 'x' units of time</td>
-    <td><ul><li>atMost= at the maximum 'x' units in <kbd>integer</kbd> format</li><li>TimeUnit = unit of time</li><li>referenceDateformat:dd-mm-yyyy</li></ul></td>
+    <td><li>atMost= at the maximum 'x' units in integer format</li><li>TimeUnit - unit of time</li><li>ReferenceDateformat : dd-mm-yyyy</li></td>
+  </tr>
+  <tr>
+    <td>DateFunctions</td>
+    <td>past</td>
+    <td>Generates past date within atmost 'x' units of time</td>
+    <td><li>Integer - Upper limit of value to be added (any random value between 0 and this value can be used)</li><li>TimeUnit - Unit of Time</li><li>String - Format of Date to be generated</li></td>
   </tr>
  <tr>
     <td>DateFunctions</td>
     <td>between</td>
     <td>Generates dates in between two dates</td>
-    <td><ul><li>from = starting date</li><li>to = ending date</li><li>format = date format dd-yy-mmmm</li></ul></td>
+    <td><li>From - Starting date</li><li>To - Ending date</li><li>Format - Date format dd-yy-mmmm</li></td>
   </tr> 
     <tr>
     <td>DateFunctions</td>
     <td>birthday</td>
     <td>Generates a random birthday</td>
-    <td><ul><li>format = Date format.<em>For example, ddmmyyyy</em></li></ul></td>
+    <td><li>Format = Date format.<em>For example, ddmmyyyy</em></li></td>
+  </tr>
+  </tr> 
+    <tr>
+    <td>StringAndDateTime</td>
+    <td>concatWithCurrentTime</td>
+    <td></td>
+    <td></td>
   </tr> 
   <tr>
     <td>DateFunctions</td>
-    <td>Date before today</td>
-    <td>Generates a date which is before today’s date</td>
-    <td><ul><li>noOfDays= number of days before the present date in <kbd>integer</kbd>format</li><li>format= Date format</li></ul> </td>
+    <td>dateBeforeToday</td>
+    <td>Generates a date which is before today's date</td>
+    <td><li>noOfDays - number of days before the present date in integer format</li><li>Format - Date format</li></td>
   </tr> 
   <tr>
     <td>DateFunctions</td>
-    <td>Date after today</td>
+    <td>dateAfterToday</td>
     <td>Generates a date which is after today’s date</td>
-    <td><ul><li>noOfDays = number of days after the present date in <kbd>integer</kbd>format</li><li>format = Date format</li></ul></td>
-  </tr>  
+    <td><li>noOfDays - number of days after the present date in integer format</li><li>Format - Date format</li></td>
+  </tr>
   <tr>
-    <td>DateFunctions</td>
-    <td>daysBeforeGivenDate</td>
-    <td>Generates a date which is before ‘x’ number of days from the given date</td>
-    <td><ul><li>date = reference date</li><li> noOfDays = number of days in integer</li><li> format = date format </li></ul></td>
-  </tr> 
-   <tr>
-    <td>DateFunctions</td>
-    <td>daysAfterGivenDate</td>
-    <td>Generates a date which is after 'x' number of days from the given date</td>
-    <td><ul><li>noOfDays = number of days in integer format</li><li>format = date format</li></ul></td>
-  </tr> 
+    <td>StringConcatenation</td>
+    <td>concatWithRandomString</td>
+    <td></td>
+    <td></td>
+  </tr>
   <tr>
-    <td>DateFunctions</td>
-    <td>currentTime</td>
-    <td>Generates current time</td>
-    <td><ul><li>format = format of time. <em>For example, hh:mm:ss dd-mm-yyyy </em></li></ul></td>
-  </tr> 
+    <td>RestTestCustom</td>
+    <td>getAdd</td>
+    <td></td>
+    <td></td>
+  </tr>   
   <tr>
     <td>Cookies</td>
     <td>getCookieNames</td>
@@ -305,7 +705,42 @@ Given below is the list of default test data generators available in Testsigma:
     <td>getCookieWithName</td>
     <td>Fetch only the cookie whose name is given</td>
     <td></td>
+  </tr>
+  <tr>
+    <td>RandomStringUtil</td>
+    <td>alphabeticString</td>
+    <td></td>
+    <td></td>
+  </tr> 
+  <tr>
+    <td>RandomStringUtil</td>
+    <td>alphabetic</td>
+    <td></td>
+    <td></td>
+  </tr>  
+  <tr>
+    <td>CustomStepTest</td>
+    <td>sampleCustomStep</td>
+    <td></td>
+    <td></td>
+  </tr> 
+  <tr>
+    <td>RestTestCustomTest</td>
+    <td>getAdd</td>
+    <td></td>
+    <td></td>
+  </tr> 
+  <tr>
+    <td>CustomFunctionSample</td>
+    <td>getAdd</td>
+    <td></td>
+    <td></td>
   </tr> 
 </table>
 </body>
 
+[[info | NOTE:]]
+| - You can create your own Data Generator and customise the actions according to your preference. For more information, refer to [create test data generators using addons](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/)
+| - For some Data Generators, Regex is used to find a sequence of characters that specifies a search pattern in the text; if you're unfamiliar, refer to the [Regex guide - MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).
+
+---

--- a/src/pages/docs/test-data/types/mailbox.md
+++ b/src/pages/docs/test-data/types/mailbox.md
@@ -19,37 +19,43 @@ contextual_links:
   name: "Store Data as a Runtime Variable from Mailbox"
   url: "#store-data-as-a-runtime-variable-from-mailbox"
 - type: link
-  name: "Generating a new mailbox with every test case execution"
-  url: "#generating-a-new-mailbox-with-every-test-case-execution"
----
+  name: "Create Mailbox Alias in Test Step"
+  url: "#create-mailbox-alias-in-test-step"
+- type: link
+  name: "Generate Mailbox Alias for Test Cases Execution"
+  url: "#generate-mailbox-alias-for-test-cases-execution"
 
 ---
 
-Mailbox test data in Testsigma can be used when:
-* You must receive an email and validate the content to understand if the OTP delivered in the email is proper. 
-* You need to validate content for emails in different languages.
-* You want to check if a user can read an entire marketing email within a specified time.
+---
 
-All of these use cases have one thing in common - A mailbox. Your test needs to be able to access the mailbox, check if the mail has been received, open the email, read it and process it.
+Mailbox test data can be utilized in Testsigma for various purposes
 
-In Testsigma, this feature is built-in. Here's how you can use it
+* Verify the accuracy of the OTP delivered via email by receiving an email and authenticating its content. 
+* Validation of email content in numerous languages.
+* Assessment of a user's ability to read an entire promotional email within a stipulated time.
 
+Here's how you can use the built-in feature in Testsigma to access the mailbox, check if the mail has been received, open the email, read it, and process it.
+
+[[info | NOTE:]]
+| Testsigma has designed the Mailbox feature to retrieve only the latest email's relevant details, such as content, OTP, and subject information.
 
 ---
 
 ### **Prerequisites**
 
-Provisioned mailbox - Contact [Testsigma Support](mailto:support@testsigma.com) or use the Instant Chat option; we will provision a mailbox for you.
+Provisioned mailbox - Contact [Testsigma Support](mailto:support@testsigma.com) or use the **Instant Chat** option; we will provision a mailbox for you.
 
 You should also be familiar with Regular expressions. If not, refer to the [Regex guide - MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
 
 ---
+
 ## **Add Mailbox in Test Step**
 
-We will enter the Email Address provided by Testsigma using the Mailbox test data type in Test Step.
+We will enter the Email Address provided by Testsigma using the Mailbox test data type in Test Step. Follow the steps below:
 
 1. Create a **new step** in the **test case**, including a placeholder for **test data** in the NLP.
-2. **Delete** the **test data** placeholder and select **&|Mailbox|** from the test data types.
+2. **Replace** the **test data** placeholder by selecting **&|Mailbox|** from the test data types dropdown menu.
 3. Select the **Email** from the right-side panel.
 
 Here is a quick GIF demonstrating the above workflow:
@@ -59,14 +65,14 @@ Here is a quick GIF demonstrating the above workflow:
 
 ## **Fetch OTP from Mailbox** 
 
-We will use the Test Data Generators available in Testsigma to store the OTP/ any data from the Mailbox selected. Refer to [Add Mailbox in Test Step](https://testsigma.com/docs/test-data/types/mailbox/#add-mailbox-in-test-step) and follow the subsequent steps.
+We will use the Test Data Generators available in Testsigma to store the OTP/ any data from the Mailbox selected. Follow the steps below:
 
 1. Create a **new step** in the **test case**, including a placeholder for **test data** and an **element** in the **NLP** to enter the OTP code in the **OTP** field.
-2. **Delete** the **test data** placeholder and select **!|Data Generator|** from the test data types.
+2. **Replace** the **test data** placeholder by selecting **!|Data Generator|** from the test data types dropdown menu.
 3. Search and select the Test Data generator function **!|MailBoxFunctions :: getEmailOTP|**.
 4. **Click** the **element** placeholder and **select** an **element** from the right side of the panel.
 5. Enter the required arguments for the function and **create** the Test Step.
-    - **Regex**: It is a sequence of characters that defines a search pattern. Here, for example, we are given **\d{4}**, which is a pattern that matches any sequence of four consecutive digits (0-9).
+    - **Regex**: A sequence of characters defines a search pattern. Here, for example, we are given **\d{4}**, which is a pattern that matches any sequence of four consecutive digits (0-9).
     -  **MailBox**: It is an email mailbox that holds incoming email messages. Select Email from the drop-down list.
     -  **Timeout**: Enter the time a programme or system is willing to wait for a particular operation to complete. Here, for example, we are given 30 seconds to wait.
 
@@ -80,14 +86,14 @@ Here is a quick GIF demonstrating the above workflow:
 
 ## **Store Data as a Runtime Variable from Mailbox**
 
-We will use the Test Data Generators available in Testsigma to store the OTP/ any data from the Mailbox selected. Refer to [Add Mailbox in Test Step](https://testsigma.com/docs/test-data/types/mailbox/#add-mailbox-in-test-step)  and follow the subsequent steps.
+We will use the Test Data Generators available in Testsigma to store the OTP/ any data from the Mailbox selected. Follow the steps below:
 
 1. Create a **new step** in the **test case**, including two placeholders for **test data** in the **NLP** to store **data** in the runtime variable.
-2. Delete the **test-data-1** placeholder and select **!|Data Generator|** from the test data types.
+2. **Replace** the **test-data-1** placeholder by selecting **!|Data Generator|** from the test data types dropdown menu.
 3. Search and select the Test Data generator function **!|MailBoxFunctions :: contentVerification|**.
-4. **Delete** the **test-data-2** placeholder and select **$|Runtime|** from the test data types. Select the runtime variable from the right side of the panel to store data.
+4. **Replace** the **test-data-2** placeholder by selecting **$|Runtime|** from the test data types dropdown menu. Select the runtime variable from the right side of the panel to store data.
 5. Enter the required arguments for the function and **create** the Test Step.
-    - **Regex**: It is a sequence of characters that defines a search pattern. Here, for example, we are given **\d{4}**, which is a pattern that matches any sequence of four consecutive digits (0-9).
+    - **Regex**: A sequence of characters defines a search pattern. Here, for example, we are given **\d{4}**, which is a pattern that matches any sequence of four consecutive digits (0-9).
     -  **MailBox**: It is an email mailbox that holds incoming email messages. Select Email from the drop-down list.
     -  **Compare String**: CompareString is a function used in programming languages to compare two strings and determine if they are equal or not.
     -  **Timeout**: Enter the time a programme or system is willing to wait for a particular operation to complete. Here, for example, we are given 30 seconds to wait.
@@ -96,30 +102,40 @@ Here is a quick GIF demonstrating the above workflow:
 ![Store Data as a Runtime Variable from Mailbox](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/overview/storeruntime_mb_ts.gif)
 
 [[info | NOTE:]]
-| You can store the subject by selecting the Test Data generator function **!|MailBoxFunctions :: subjectVerification|**.
+| You can store the subject by selecting the Test Data Generator function: **!|MailBoxFunctions :: subjectVerification|**.
 
 ---
 
-## **Generating a new mailbox with every test case execution**
+## **Create Mailbox Alias in Test Step**
 
-Sometimes, you may need to test some email-based functionalities for multiple new accounts with limited email addresses. In such scenarios, with Testsigma, you can generate new aliases every time during the test case execution.
+In the test step; you can create a mailbox alias that associates an additional email address with your primary email account. You can use it to create multiple email addresses that all lead to the same inbox. It generates a unique mailbox every time you execute it during test execution.
 
-The NLPs that can be used for the same are as below (It is recommended to use the Addons like 'String Data Generators' and 'String Actions' with the NLPs mentioned below - to store email in the runtime variable and verify the email messages.):
+1. Create a **new step** in the **test case**, including two placeholders for **test data** in the **NLP** to create a mailbox alias.
+2. **Replace** the **test-data-1** placeholder by selecting **!|Data Generator|** from the test data types dropdown menu.
+3. Search and select the Test Data generator function **!|MailBoxAliasFunctions :: generateMailBoxAlias|**.
+4. **Delete** the **test-data-2** placeholder and enter text by creating a runtime variable and storing the email. Here, for example, we are given **Email1** as a runtime variable. Alternatively, select **$|Runtime|** from the **test data types** and store the email by selecting the runtime variable from the right side of the panel.
 
-|**String Data Generators**|**String Actions**|
-|---|---|
-|**!\|MailBoxAliasFunctions :: generateMailBoxAlias\|**|This NLP will generate a unique mailbox every time it is executed during test execution.|
-|**!\|MailBoxAliasFunctions :: getEmailContent\|**|This will get the entire email's content into a variable.|
-|**!\|MailBoxAliasFunctions :: getEmailSubject\|**|This will get the entire email's subject into a variable.|
-|**!\|MailBoxAliasFunctions :: getOTP\|**|This will fetch the OTP sent to the email box into a variable.|
-|**!\|MailBoxAliasFunctions :: urlWithText\|**|This will fetch the URL that contains some required text.|
-|**!\|MailBoxAliasFunctions :: urlWhichContains\|**|This will fetch the URL that contains some required parameters.|
-|**!\|MailBoxAliasFunctions :: urlMatchingRegex\|**|This will fetch the URL that contains a URL matching the required regex.|
+Here is a quick GIF demonstrating the above workflow:
+![Mailbox Alias in Test Step](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/overview/mailboxalias_ts.gif)
+---
+
+## **Generate Mailbox Alias for Test Cases Execution**
+
+Sometimes, you may need to test email-based functionalities for multiple new accounts with limited email addresses. In such scenarios, Testsigma allows you to generate new aliases every time during the test case execution.
+
+Below are the NLP tools that you can use for the same. It would be best to use add-ons such as **Data Generators** and **Actions** with the NLP tools mentioned below to store email in the runtime variable and verify the email messages.
+
+
+|**Data Generators**|**Actions**|**Inputs**|
+|---|---|---|
+|**!\|MailBoxAliasFunctions :: getEmailContent\|**|This will get the entire email's content into a variable.|Runtime Variable, Timeout in seconds|
+|**!\|MailBoxAliasFunctions :: getEmailSubject\|**|This will get the entire email's subject into a variable.|Runtime Variable, Timeout in seconds|
+|**!\|MailBoxAliasFunctions :: getOTP\|**|This will fetch the OTP sent to the email box into a variable.|Regex, Runtime Variable,Timeout in seconds|
+|**!\|MailBoxAliasFunctions :: urlWithText\|**|This will fetch the URL that contains some required text.|Text, Runtime Variable,Timeout in seconds|
+|**!\|MailBoxAliasFunctions :: urlWhichContains\|**|This will fetch the URL that contains some required parameters.|Substring, Runtime Variable,Timeout in seconds|
+|**!\|MailBoxAliasFunctions :: urlMatchingRegex\|**|This will fetch the URL that contains a URL matching the required regex.|Regex, Runtime Variable,Timeout in seconds|
 
 Below is a screenshot showing a test case generating a mailbox alias and getting content from the email.
 ![A test case displaying how to generate unique email address and how to use it](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/test-data/types/mailbox/generate-unique-email.png)
 
-
 ---
-
-


### PR DESCRIPTION
Added Mailbox Alias to the Mailbox TDT Doc and Updated Default Test Data Generator Document for the tickets https://testsigma.atlassian.net/browse/DOC-129 and https://testsigma.atlassian.net/browse/DOC-134.
![image](https://user-images.githubusercontent.com/119392848/225914990-af52fa4d-1041-4dc3-bc09-5db46e6f1315.png)
![image](https://user-images.githubusercontent.com/119392848/225915120-4062fea9-37e9-4373-a42c-5eb5e92a3daa.png)

