### PR TITLE
fix: UI issue on table contents which is overlapping layout on docs page.

### DIFF
--- a/src/templates/page.jsx
+++ b/src/templates/page.jsx
@@ -136,7 +136,7 @@ export default ({ data, pageContext }) => {
                                     <span dangerouslySetInnerHTML={{ __html: post.html }} />
                                 </div>
                             </main>
-                            <aside className="isGithubEdit w-1/5">
+                            <aside className="isGithubEdit w-1/5 bg-white">
                                 <hr className="d-block lg:hidden"/>
                                 <div className="top-0 top-1 border-l pl-4 py-16 sticky">
                                     <div className="edit-button">

--- a/src/templates/page.scss
+++ b/src/templates/page.scss
@@ -656,3 +656,29 @@ table{
     }
   }
 }
+
+// Cookie banner
+#hs-banner-parent{
+  .hs-cookie-notification-position-bottom{
+    width: calc(min(25em, 100%));
+    @apply left-[12%];
+    @media only screen and (max-width: 767px) {
+      @apply left-[3%] w-[95%];
+    }
+    @media only screen and (min-width:768px) and (max-width: 1023px) {
+      @apply left-[20%] w-[35%];
+    }
+    #hs-eu-cookie-confirmation-inner{
+      @apply p-8;
+      #hs-eu-policy-wording{
+        @apply mr-0 mb-4;
+      }
+      #hs-eu-cookie-confirmation-buttons-area{
+        @apply justify-center mr-0;
+        #hs-eu-decline-button{
+          @apply hidden;
+        }
+      }
+    }
+  }
+}

--- a/src/templates/page.scss
+++ b/src/templates/page.scss
@@ -642,3 +642,17 @@ code[class*="language-"] {
 .fixed{
   display: none;
 }
+
+table{
+  thead, tbody{
+    @apply w-full;
+    tr{
+      td, th{
+        word-wrap: break-word;
+        li{
+          @apply break-all w-full;
+        }
+      }
+    }
+  }
+}

--- a/src/templates/page.scss
+++ b/src/templates/page.scss
@@ -661,12 +661,14 @@ table{
 #hs-banner-parent{
   .hs-cookie-notification-position-bottom{
     width: calc(min(25em, 100%));
-    @apply left-[12%];
+    left: 12%;
     @media only screen and (max-width: 767px) {
-      @apply left-[3%] w-[95%];
+      left: 3%;
+      width: 95%;
     }
     @media only screen and (min-width:768px) and (max-width: 1023px) {
-      @apply left-[20%] w-[35%];
+      left: 20%;
+      width: 35%;
     }
     #hs-eu-cookie-confirmation-inner{
       @apply p-8;


### PR DESCRIPTION
Fixed UI issue on table contents which is overlapping layout on docs page.

<img width="1840" alt="image" src="https://github.com/testsigmahq/testsigma-docs/assets/117272529/1022c37e-de28-430e-8340-34fe76660699">
