### PR TITLE
fix: Typo in Agent Docker M1 documentation

### DIFF
--- a/src/pages/docs/agent/setup-on-windows-mac-linux.md
+++ b/src/pages/docs/agent/setup-on-windows-mac-linux.md
@@ -333,7 +333,7 @@ There are two ways of starting the testsigma local agent using docker:
           FIREFOX: "http://firefox:4444"
           EDGE: "<REMOTE_EDGE_URL>"
       chrome:
-        image: seleniarm/standalone-chrome:latest
+        image: seleniarm/standalone-chromium:latest
         shm_size: 1gb
         ports:
           - "4444:4444"


### PR DESCRIPTION
Page : https://testsigma.com/docs/agent/setup-on-windows-mac-linux/

It should be  seleniarm/standalone-chromium:latest

 seleniarm/standalone-chrome:latest is invalid and will say image not found.
 

https://github.com/seleniumhq-community/docker-seleniarm


<img width="1028" alt="Screenshot 2024-01-30 at 11 21 51 PM" src="https://github.com/testsigmahq/testsigma-docs/assets/104123866/4f105434-c873-4528-a03e-a13b830a151f">
