### PR TITLE
Updated troubleshooting doc for Agent

### DIFF
--- a/src/pages/docs/troubleshooting/agent/mobile-device-not-displayed-recorder.md
+++ b/src/pages/docs/troubleshooting/agent/mobile-device-not-displayed-recorder.md
@@ -1,120 +1,121 @@
 ---
-title: "Testsigma Agent not detecting local devices for mobile test recorder"
-page_title: " Troubleshooting “Testsigma Agent not detecting Local Devices for Mobile Test Recorder” error"
+title: "Testsigma Agent's Failure to Detect Local Devices for Mobile Test Recorder"
+page_title: "Resolve Mobile Test Recorder Issue Device Detection Failures"
 metadesc: "Know the possible reasons why Testsigma Agent not detecting Local Devices for Mobile Test Recorder and learn steps to fix the issue by troubleshooting"
 noindex: false
 order: 23.2
-page_id: "Testsigma Agent not detecting Local Devices for Mobile Test Recorder"
+page_id: "troubleshoot-testsigma-agent-mobile-test-recorder-page"
 warning: false
 contextual_links:
 - type: section
   name: "Contents"
 - type: link
-  name: "Causes"
-  url: "#Causes"
+  name: "Common Causes"
+  url: "#common-causes"
 - type: link
-  name: "Android device"
-  url: "#Android-device"
+  name: "Android Device"
+  url: "#android-device"
 - type: link
-  name: "ADB does not recognize the device connected to the system"
+  name: "ADB does not Recognize the Device Connected to the System"
   url: "#adb-does-not-recognize-the-device-connected-to-the-system"
 - type: link
-  name: "iOS device"
-  url: "#iOS-device"
+  name: "iOS Device"
+  url: "#ios-device"
 
 ---
 
 ---
-<p>
-This article provides methods to solve the error <em>Testsigma agent not detecting local devices for mobile test recorder</em> for Android and iOS devices.
-</p>
 
-## **General causes**
+<p>This guide offers solutions to the issue of Testsigma Agent not detecting local devices for the mobile test recorder on Android and iOS devices. Below, it provides potential causes and steps to resolve them.</p>
+
+---
+
+## **Common causes**
 
 Testsigma agent may be unable to detect your local mobile device for the test recorder for the following reasons:
 <ul>
-
-<li><strong>Testsigma Agent is not up-to-date</strong>: Testsigma Agent includes an automatic update feature. However, if the auto-update fails due to bad network conditions or incorrect configuration, you can update the Agent manually. <em>For more information refer to,
-<a href="https://testsigma.com/docs/agent/update-agent-manually/">updating Testsigma agent manually</a></em>.
-</li>
-
-<li><strong>Damaged or faulty USB ports or cables</strong>: In this case, you should try connecting to a different the USB port or use a different cable.</li>
-<li>A weak Wi-Fi signal, if your device is connected via Wi-Fi.</li>
+<li><strong>Testsigma Agent is not up-to-date</strong>: Ensure you keep Testsigma Agent up-to-date. The Agent's automatic update may fail due to network issues or incorrect configurations. Refer to the guide on <a href="https://testsigma.com/docs/agent/update-agent-manually/">updating Testsigma Agent manually</a> to update Agent manually.</li>
+<li id="usb-unstable"><strong>Damaged or faulty USB ports or cables</strong>: Try connecting to a different USB port or using an alternative cable if your current one is damaged.</li>
+<li><strong>Weak Wi-Fi Signal</strong>: If you have connected your device wirelessly, ensure a stable Wi-Fi connection.</li>
 </ul>
 <br>
 
 ---
 
-## **Android device**
+## **Android Device**
 
-**Causes**
+### **Common Causes for Android Devices**
+
 <ul>
-<li><strong>Developer options and USB debugging are disabled</strong>: To enable developer options and USB debugging, refer to <a href="https://testsigma.com/docs/agent/connect-android-local-devices/">setting up local Android device</a>.
-</li>
-<li><strong>Android Debug Bridge (ADB) fails to recognize the device connected to the system</strong>: To verify if ADB recognizes your device, refer to the section below (ADB does not recognize the device connected to the system).</li>
-<li><strong>Desired capabilities are not modified as per device or application.</strong> To modify desired capabilities, refer to <a href="https://testsigma.com/docs/desired-capabilities/overview/">desired capabilities</a> and a <a href="https://testsigma.com/docs/desired-capabilities/most-common/">list of desired capabilities</a>.</li>
-<li><strong>Driver installation error</strong>: Testsigma agent installs <kbd>AppiumSettings</kbd> and <kbd>UIAutomator Server</kbd> apps to aid running executions on Android devices. If this fails, a notification is displayed reading <em>Failed to install drivers</em>. In such instances, ensure your device remains connected for some time to finish installing drivers.</li>
-</ul>
-
-## **Android Debug Bridge does not recognize the device connected to the system**
-
-To verify if the ADB interface does not recognize your Android device, follow the below steps:
-
-* Navigate to the folder containing ADB and open the command prompt. From the command line, type <kbd>adb devices</kbd>.If connected, you will see the list of devices attached. If the device is connected successfully, the response would be as shown in the figure below:</li>
-
-![adb devices command execution](https://docs.testsigma.com/images/mobile-device-not-displayed-recorder/adb-devices-command-execution.png) where `AVY9KA90322022030`is the device ID.
-
-* If your device is not displayed in the response, it indicates a hardware or communication problem between Android and your PC. Follow the below steps to troubleshoot the issue.
-
-
-[[info | NOTE:]]
-|We need to make sure that the Android SDK is installed in the system and its environment path is set, before running the ADB command.
-
-### **How to troubleshoot**
-<ol>
-<li>Restart your Android device.</li>
-<li>If restarting does not resolve the issue, then try the following: 
+<li><strong>Disabled Developer Options and USB Debugging</strong>: Follow the steps to <a href="https://testsigma.com/docs/agent/connect-android-local-devices/">set up a local Android device</a> to enable Developer Options and USB debugging.</li>
+<li><strong>Android Debug Bridge (ADB) Recognition Failure</strong>: Verify the ADB recognition by following the steps below if <a href="https://testsigma.com/docs/troubleshooting/agent/mobile-device-not-displayed-recorder/#adb-does-not-recognize-the-device-connected-to-the-system"> ADB does not recognize the device connected to the system </a>.</li>
+<li><strong>Desired Capabilities Not Modified</strong>: Use the guide on <a href="https://testsigma.com/docs/desired-capabilities/overview/">desired capabilities</a> to modify desired capabilities according to your device or application.</li>
+<li id="driver-install-error"><strong>Driver installation error</strong>: If you encounter a <strong>Failed to install drivers</strong> message, follow these steps: <img src="https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/diver_installation_android.png" alt="driver-install-error"></a>
      <ol type="a">
-     <li>On your device, turn off USB debugging and then turn it back on again.</li>
-     <li>Plug the USB cable into a different USB port on your computer.</li>
-     <li>Unplug or replug the USB cable from your Android device. Ensure that the USB cable fits tightly into your Android device’s USB port, then try syncing again.</li>
-     <li>Try replacing the USB cable with one that fits more tightly into your Android device's USB port.</li>
-     </ol>
-</ol>
+     <li>Allow time for the driver installation to finish.</li>
+     <li>Check device memory for sufficient space.</li>
+     <li>Uninstall <strong>AppiumSettings</strong> and <strong>UI Automator Server</strong> apps, then restart the agent.<img src="https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/uninstall_appiumapp.png" alt="uninstall_appiumapp"></a></li> 
+     </ol> 
+</li>
+</ul>
 
 ---
 
-##  **iOS device**
+## **ADB does not Recognize the Device Connected to the System**
 
-###**Causes**
+If Android Debug Bridge (ADB) fails to recognize your connected Android device, you should follow these steps to troubleshoot the problem.
+
+### **Verification Steps**:
+
+1. Navigate to the folder containing ADB.
+2. Open the command prompt and type **adb devices**.
+3. If you connect, the command prompt will display a list of attached devices, as shown in the example below: ![adb devices command execution](https://docs.testsigma.com/images/mobile-device-not-displayed-recorder/adb-devices-command-execution.png)
+    Here, **AVY9KA90322022030** is the device ID.
+
+### **If Your Device Is Not Displayed**:
+
+If the response does not display your device, it indicates a hardware or communication problem between Android and your PC. Follow the steps below to troubleshoot the issue.
+
+[[info | NOTE:]]
+| Ensure you have installed the Android SDK on your system and set its environment path before running the ADB command.
+
+### **Troubleshooting Android Device**
+
+1. **Restart Your Android Device**: Begin by restarting your Android device.
+2. **Turn Off and On USB Debugging**: On your device, turn off USB debugging and then re-enable it.
+3. **Change USB Port**: Plug the USB cable into a different USB port on your computer.
+4. **Unplug and Replug USB Cable**: Disconnect and reconnect the USB cable from your Android device, ensuring it fits securely into the device's USB port. Then, attempt syncing again.
+5. **Replace USB Cable**: Try using a different USB cable that fits more securely into your Android device's USB port.
+
+---
+
+##  **iOS Device**
+
+Refer to the following information to troubleshoot and resolve common issues if you encounter problems with your iOS device.
+
+### **Common Causes for iOS Devices**
 
 <ul>
-<li><strong>Device locked</strong>: iOS devices require the device to be unlocked to allow Testsigma Agent to mount developer image and run apps on the device.
-If the device is locked, a notification is displayed reading 'Unlock device'.</li>
-<li><strong>Computer not trusted</strong>: iOS devices require the connected computer running Testsigma Agent to be Trusted. This is required to mount developer image and run apps on the device.To <strong>Trust</strong> your computer,select your device in <strong>Finder</strong> and click <strong>Trust</strong>.</li>
-<li><strong>Developer image could not be mounted</strong>: iOS devices require developer disk image to be mounted to allow Testsigma Agent run apps on the device. Ensure provisioning profile is added on Settings > iOS Settings page.
-If profile is not configured, a notification reading 'Ensure profile exists in iOS Settings' is displayed.</li>
+<li id="device-locked"><strong>Device locked</strong>: You must unlock iOS devices to enable Testsigma Agent to mount the developer image and run apps. A notification displaying 'Unlock device' is shown if the device is locked. If the device is locked, a notification reads 'Unlock device'.</li>
+<li id="device-trust"><strong>Computer not trusted</strong>: You must <strong>trust</strong> the connected iOS device to ensure that Testsigma Agent functions correctly. To establish trust, select your device in <strong>Finder</strong> and click <strong>Trust</strong>'.</li>
+<li id="device-mount"><strong>Developer Image Not Mounted</strong>: Testsigma Agent requires mounting the developer disk image on iOS devices to run apps. You should ensure that the provisioning profile is added in <strong>Settings</strong> > <strong>iOS Settings</strong>. A notification indicating a configuration issue says, 'Ensure profile exists in iOS Settings'.</li>
 </ul>
 
-For iOS devices follow the below steps to resolve the issue.
+### **Troubleshooting iOS Device**
 
-### **How to troubleshoot**
+Troubleshoot and resolve issues with iOS devices by following these steps.
 
 <ol>
-<li>Turn off the iOS device.</li>
-<li>Turn off the Testsigma agent.</li>
-<li>Open <strong>Task Manager</strong> on your computer, and terminate the following applications or processes:
-<ol>
-<li>NodeJS</li>
-<li>tidevice</li></ol>
-</li>
-<li>Delete Testsigma agent logs. <em>For more information on locating agent logs, refer to <a href="https://testsigma.com/docs/agent/troubleshooting/logs/">fetching agent test logs</a>.</em>
-</li>
-<li>Restart the Testsigma agent.</li>
-<li>Restart the iOS device and connect it to your computer.</li>
-<li>If the iOS device does not appear on the list of connected devices, connect the device with a different USB port on your computer.</li>
+<li><strong>Turn Off iOS Device</strong>: Begin by turning off your iOS device.</li>
+<li><strong>Turn Off Testsigma Agent</strong>: Turn off Testsigma Agent.</li>
+<li><strong>Terminate Applications or Processes</strong>: Open <strong>Task Manager</strong> on your computer and terminate the following applications or processes <strong>NodeJS</strong>, <strong>tidevice</strong>.</li>
+<li><strong>Delete Testsigma Agent Logs</strong>: Locate and delete Testsigma Agent logs. For more information, refer to <a href="https://testsigma.com/docs/agent/troubleshooting/logs/">fetching agent test logs</a>.</li>
+<li><strong>Restart Testsigma Agent</strong>: Restart the Testsigma agent.</li>
+<li><strong>Restart iOS Device and Connect</strong>: Reboot your iOS device and connect it to your computer.</li>
+<li><strong>Change USB Port</strong>: If the iOS device does not appear on the list of connected devices, connect the device with a different USB port on your computer.</li>
 </ol>
 
-If the above troubleshooting steps did not help and the issue persists, [connect with Testsigma Support on Discord](https://discord.com/invite/5caWS7R6QX) or reach out to s     [support@testsigma.com](mailto:support@testsigma.com).
+[[info | NOTE:]]
+| If the troubleshooting steps above do not resolve the problem, you can contact **Testsigma Support** on [Discord](https://discord.com/invite/5caWS7R6QX) or [support@testsigma.com](mailto:support@testsigma.com). You can also use the **Instant Chat** Options for prompt assistance.
 
 ---


### PR DESCRIPTION
Updated the error information for the failure of the Testsigma agent to detect local devices for the Mobile Test Recorder document. The associated ticket is https://testsigma.atlassian.net/browse/IDEA-996.
<img width="1439" alt="Screenshot 2024-03-07 at 9 38 41 AM" src="https://github.com/testsigmahq/testsigma-docs/assets/119392848/c15209eb-7cba-4f39-958f-b2eb77eba902">
