### PR TITLE
New doc for Recorder Extension: Edge

### DIFF
--- a/src/left-nav-title.json
+++ b/src/left-nav-title.json
@@ -622,5 +622,11 @@
   },
   "install-firefox-extension":{
     "/docs/test-step-recorder/install-firefox-extension/": "Install Firefox Extension"
+  },
+  "install-edge-extension":{
+    "/docs/test-step-recorder/install-edge-extension/": "Install Edge Extension"
+  },
+  "install-chrome-extension":{
+    "/docs/test-step-recorder/install-chrome-extension/": "Install Chrome Extension"
   }
 }

--- a/src/pages/docs/test-step-recorder/install-chrome-extension.md
+++ b/src/pages/docs/test-step-recorder/install-chrome-extension.md
@@ -1,5 +1,5 @@
 ---
-title: "Install Chrome Extension"
+title: "Install Testsigma Recorder Extension: Chrome"
 order: 7.11
 page_id: "Install Chrome Extension"
 page_title: "Installing Chrome Extension"
@@ -22,9 +22,10 @@ contextual_links:
 With Testsigma's Chrome extension, users can quickly record test steps by capturing user interactions, such as clicking buttons, entering text, navigating through pages, etc. The extension will also help users create elements interacting with the application during testing. This article explains how to install Testsigma's Chrome extension. 
 
 ---
+
 ## **Steps to Install Chrome Extension**
 
-1. Go to: [Testsigma Recorder](https://chrome.google.com/webstore/detail/testsigma-recorder/epmomlhdjfgdobefcpocockpjihaabdp)
+1. Go to [Testsigma Recorder](https://chrome.google.com/webstore/detail/testsigma-recorder/epmomlhdjfgdobefcpocockpjihaabdp)
 
 2. Click on **Add to Chrome**.
 ![Add to Chrome](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/tsceatc.png)
@@ -36,7 +37,8 @@ With Testsigma's Chrome extension, users can quickly record test steps by captur
 ![Message](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/tscesa.png)
 
 Here’s a GIF demonstrating how to add Testsigma's Chrome extension.
-![Chrome Extension](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/ChromeExtensionDS.gif)
+
+![Chrome Extension](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/EnableChromeExt.gif)
 
 *For more information on creating test steps using recorder, refer to [recording test steps](https://testsigma.com/docs/test-cases/create-steps-recorder/web-apps/overview/).*
 
@@ -68,6 +70,6 @@ You can record steps in incognito mode by enabling the "Allow in Incognito" opti
 
 Here’s a GIF demonstrating how to enable the **Allow in Incognito** option and record steps in Incognito.
 
-![Allow in Incognito](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/TestsOnIncognitoMode.gif)
+![Allow in Incognito](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/IncognitoGifNew.gif)
 
 ---

--- a/src/pages/docs/test-step-recorder/install-edge-extension.md
+++ b/src/pages/docs/test-step-recorder/install-edge-extension.md
@@ -1,0 +1,65 @@
+---
+title: "Install Testsigma Recorder Extension: Edge"
+page_title: "Installing Testsigma Recorder Extension in Edge"
+metadesc: "Effortlessly install the Testsigma Recorder Extension in Edge. This extension will help you record test steps for Web, Mobile & Mobile Web applications"
+noindex: false
+order: 7.13
+page_id: "install-testsigma-recorder-in-edge"
+warning: false
+contextual_links:
+- type: section
+  name: "Contents"
+- type: link
+  name: "Steps to Install Edge Extension"
+  url: "#steps-to-install-edge-extension"
+- type: link
+  name: "Record Steps in InPrivate Mode"
+  url: "#record-steps-in-inprivate-mode"
+---
+
+---
+
+With Testsigma's Edge Extension, users can quickly record test steps and create test cases by capturing UI interactions. The extension will also auto-learn elements that interact with the application during testing. This article discusses installing Testsigma's Extension in Edge.
+
+---
+
+## **Steps to Install Edge Extension**
+
+1. Go to [Testsigma Recorder](https://microsoftedge.microsoft.com/addons/detail/testsigma-recorder/pdgdbfedjpffcnmgedicplikkejikhif)
+
+2. Click on **Get**.
+![Get](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/egget.png)
+
+3. On the permission prompt, click on **Add Extension**.
+![Add Extension](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/egaext.png)
+
+4. On successful installation, the following message will appear:
+![Success Messaga](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/egsmosi.png)
+
+
+Here’s a GIF demonstrating how to add Testsigma's Edge Extension.
+![Add Edge Extension](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/EdgeExtension.gif)
+
+---
+
+## **Record Steps in InPrivate Mode**
+
+You can record steps in private mode by enabling the Allow in InPrivate option in the Testsigma manage extension. This feature lets you record steps privately without storing browsing history or cookies. Follow the steps below to enable the “Allow in InPrivate” option in the Testsigma extension in Edge browser.
+
+---
+
+### **Extension Settings for InPrivate Mode**
+
+**1. Open the Testsigma Extension:** Go to **Extensions** and click the meatballs menu on Testsigma extension icon in the browser toolbar.
+![Go to Extension](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/eggtext.png)
+
+**2. Access Extension Settings:** From the extension menu, select **Manage Extension**.
+![Manage Extension](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/egmexten.png)
+
+**3. Enable Allow in InPrivate:** Toggle on **Allow in InPrivate** option. 
+![Enable InPrivate](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/egeipb.png)
+
+Here’s a GIF demonstrating how to enable the "Allow in InPrivate" option for Testsigma Edge Extension.
+![InPrivate Mode](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/EdgeIncognito.gif)
+
+---

--- a/src/pages/docs/test-step-recorder/install-firefox-extension.md
+++ b/src/pages/docs/test-step-recorder/install-firefox-extension.md
@@ -1,5 +1,5 @@
 ---
-title: "Install Testsigma Recorder Extension in Firefox"
+title: "Install Testsigma Recorder Extension: Firefox"
 page_title: "Install Testsigma Recorder Extension in Firefox Easily"
 metadesc: "Effortlessly start installing the Testsigma Recorder Extension in Firefox. Follow simple steps to record interactions for efficient testing. Learn more now."
 noindex: false
@@ -43,7 +43,7 @@ After installing the extension, configure it as follows:
 1. Click the **Extension** icon in the top right corner.
 2. Navigate to **Manage Your Extensions**.
 3. In the **Testsigma Recorder** extension and click on the **Menu** icon, then select **Manage**.
-4. Under **Testsigma Recorder** details, go to the **Permission** tab and toggle on **Access your data for all windows** ![Allow Extension to access data](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/config_firefox_extensions.gif)
+4. Under **Testsigma Recorder** details, go to the **Permission** tab and toggle on **Access your data for all windows**. ![Allow Extension to access data](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/config_firefox_extensions.gif)
 
 ### **Privacy & Security Settings** 
 

--- a/src/pages/docs/test-step-recorder/settings-include-exclude-attributes.md
+++ b/src/pages/docs/test-step-recorder/settings-include-exclude-attributes.md
@@ -2,7 +2,7 @@
 title: "Exclude Attributes/Classes"
 metadesc: "Learn how to exclude certain attributes/classes while capturing elements from your website | Enhance skills with this doc to exclude certain attributes/classes."
 noindex: false
-order: 7.13
+order: 7.14
 page_id: "Exclude Attributes/Classes"
 warning: false
 contextual_links:


### PR DESCRIPTION
Added a new document for Testsigma recorder extension in Edge as per the ticket https://testsigma.atlassian.net/browse/IDEA-1195.
![image](https://github.com/testsigmahq/testsigma-docs/assets/118433150/9925823e-14e9-4ff3-a759-c6a49ec162d2)
