### PR TITLE
Added Interlinks in SF Docs & Reordered SF section

### DIFF
--- a/src/pages/docs/best-practices/best-practices.md
+++ b/src/pages/docs/best-practices/best-practices.md
@@ -3,7 +3,7 @@ title: "Testsigma Automation Standards and Best Practices"
 page_title: "Enhance Efficiency with Automated Testing Best Practices"
 metadesc: "Explore best practices for enhancing efficiency and reliability in automated testing through modular design, dynamic waits, and data-driven testing."
 noindex: false
-order: 27.1
+order: 29.1
 page_id: "Best Practices to follow Testsigma Automation Standards"
 warning: false
 contextual_links:

--- a/src/pages/docs/salesforce-testing/connected-app.md
+++ b/src/pages/docs/salesforce-testing/connected-app.md
@@ -3,7 +3,7 @@ title: "Creating a Connected App"
 page_title: "Create a Connected App"
 metadesc: "A connected app is important to link external applications & the Salesforce ecosystem. This article discusses how to create a connected app in Salesforce."
 noindex: false
-order: 29.2
+order: 27.2
 page_id: "Create Connected Application"
 warning: false
 contextual_links:

--- a/src/pages/docs/salesforce-testing/create-sf-project.md
+++ b/src/pages/docs/salesforce-testing/create-sf-project.md
@@ -3,7 +3,7 @@ title: "Creating a Salesforce Project"
 page_title: "Creating a Salesforce Project"
 metadesc: "Create and manage projects for Salesforce applications. This article discusses how to create a project for Salesforce testing in Testsigma."
 noindex: false
-order: 29.3
+order: 27.3
 page_id: "Testsigma for Salesforce Test Automation"
 warning: false
 contextual_links:
@@ -27,8 +27,8 @@ In Testsigma, users can create and manage multiple projects and applications. Cr
 
 ## **Prerequisites**
 
-- A Salesforce org with test setup
-- Salesforce connected app
+- Salesforce organization with the test setup.
+- Salesforce connected app. For more information, refer to [creating a connected app](https://testsigma.com/docs/salesforce-testing/special-nlps/).
 
 ---
 

--- a/src/pages/docs/salesforce-testing/element-repos.md
+++ b/src/pages/docs/salesforce-testing/element-repos.md
@@ -3,7 +3,7 @@ title: "Salesforce Element Repositories"
 page_title: "Element Repositories"
 metadesc: "Elements repositories from Salesforce are imported after successfully synchronizing metadata. This article discusses Salesforce elements repositories."
 noindex: false
-order: 29.7
+order: 27.7
 page_id: "Element Repositories"
 warning: false
 contextual_links:

--- a/src/pages/docs/salesforce-testing/introduction.md
+++ b/src/pages/docs/salesforce-testing/introduction.md
@@ -3,7 +3,7 @@ title: "Intro: Testsigma for Salesforce Testing"
 page_title: "Introduction: Testsigma for Salesforce Test Automation"
 metadesc: "Salesforce Testing with Testsigma helps reduce average test authoring time by 50%, and test case execution will be 2X faster with a user-friendly interface"
 noindex: false
-order: 29.1
+order: 27.1
 page_id: "Testsigma for Salesforce Test Automation"
 warning: false
 contextual_links:
@@ -28,16 +28,21 @@ Salesforce is a cloud-based Customer Relationship Management (CRM) platform that
 
 ## **Setup**
 
-- For setup, refer to creating a connected app and configuring metadata connection.
+- For setup, refer to [creating a connected app](https://testsigma.com/docs/salesforce-testing/connected-app/) and [configuring metadata connection](https://testsigma.com/docs/salesforce-testing/metadata-connections/).
 
 ---
 
 ## **Getting Started**
 
-- Create User Connections
-- Live Test Authoring
-- Element Repositories
-- Special NLPs
+- [Creating Salesforce Projects](https://testsigma.com/docs/salesforce-testing/create-sf-project/)
+
+- [Adding User Connections](https://testsigma.com/docs/salesforce-testing/user-connections/)
+
+- [Build Test Cases (Manual+Live)](https://testsigma.com/docs/salesforce-testing/sf-test-cases/)
+
+- [Element Repositories](https://testsigma.com/docs/salesforce-testing/element-repos/)
+
+- [List of Special NLPs](https://testsigma.com/docs/salesforce-testing/special-nlps/)
 
 ---
 

--- a/src/pages/docs/salesforce-testing/metadata-connections.md
+++ b/src/pages/docs/salesforce-testing/metadata-connections.md
@@ -3,7 +3,7 @@ title: "Creating Metadata Connections"
 page_title: "Metadata Connections"
 metadesc: "A Metadata connection enables actions like refreshing metadata, configurations, creating objects, & managing components that define how the application behaves"
 noindex: false
-order: 29.4
+order: 27.4
 page_id: "Creating Metadata Connections"
 warning: false
 contextual_links:
@@ -31,8 +31,8 @@ In Testsigma, you can create a Salesforce application and establish a Metadata c
 
 ## **Prerequisites**
 
-- You need to have Salesforce org with test setup
-- Salesforce connected app
+- Salesforce organization with the test setup.
+- Salesforce connected app. For more information, refer to [creating a connected app](https://testsigma.com/docs/salesforce-testing/special-nlps/).
 
 ---
 

--- a/src/pages/docs/salesforce-testing/sf-test-cases.md
+++ b/src/pages/docs/salesforce-testing/sf-test-cases.md
@@ -3,7 +3,7 @@ title: "Test Cases for Salesforce (Manual + Live)"
 page_title: "Build Test Cases for Salesforce Testing"
 metadesc: "Creating test cases for Salesforce automation is easy with Salesforce metadata artifacts and capabilities from Testsigma like smart NLPs, and the debugger"
 noindex: false
-order: 29.6
+order: 27.6
 page_id: "Test Cases for Salesforce"
 warning: false
 contextual_links:
@@ -33,9 +33,9 @@ Here’s a quick video demonstrating how create test cases for Salesforce testin
 
 ## **Prerequisites**
 
-- A Salesforce organization with the test setup
-- A Salesforce connected app
-- Salesforce metadata connected to Testsigma
+- Salesforce organization with the test setup.
+- Salesforce connected app. For more information, refer to [creating a connected app](https://testsigma.com/docs/salesforce-testing/special-nlps/).
+- Salesforce metadata connected to Testsigma. For more information, refer to [creating metadata connections](https://testsigma.com/docs/salesforce-testing/metadata-connections/).
 - [Testsigma Chrome Extension](https://chromewebstore.google.com/detail/testsigma-recorder/epmomlhdjfgdobefcpocockpjihaabdp)
 
 ---

--- a/src/pages/docs/salesforce-testing/special-nlps.md
+++ b/src/pages/docs/salesforce-testing/special-nlps.md
@@ -3,7 +3,7 @@ title: "Intro: Testsigma Special NLPs"
 page_title: "Special NLPs"
 metadesc: "With special NLPs, you can build & enhance Salesforce tests with ease, reducing test authoring time by 50%. This article discusses the capabilities of these special NLPs"
 noindex: false
-order: 29.8
+order: 27.8
 page_id: "Special NLPs"
 warning: false
 contextual_links:
@@ -26,9 +26,9 @@ With Testsigma's special NLPs, you can scale and enhance Salesforce Testing. The
 
 ## **Prerequisites**
 
-- A Salesforce connected app
+- Salesforce connected app. For more information, refer to [creating a connected app](https://testsigma.com/docs/salesforce-testing/special-nlps/).
 
-- Salesforce metadata connected to Testsigma
+- Salesforce metadata connected to Testsigma. For more information, refer to [creating metadata connections](https://testsigma.com/docs/salesforce-testing/metadata-connections/).
 
 ---
 

--- a/src/pages/docs/salesforce-testing/user-connections.md
+++ b/src/pages/docs/salesforce-testing/user-connections.md
@@ -3,7 +3,7 @@ title: "Adding User Connections"
 page_title: "User Connections"
 metadesc: "Add user connections for a Salesforce project in Testsigma. These connections are associated with Salesforce user profiles like Salesforce admin/sales rep"
 noindex: false
-order: 29.5
+order: 27.5
 page_id: "User Connections"
 warning: false
 contextual_links:
@@ -31,9 +31,9 @@ Once you've set up the Salesforce Metadata connection, you can add user connecti
 
 ## **Prerequisites**
 
-- A Salesforce organization with the test setup
-- A Salesforce connected app
-- Salesforce metadata connected to Testsigma
+- Salesforce organization with the test setup.
+- Salesforce connected app. For more information, refer to [creating a connected app](https://testsigma.com/docs/salesforce-testing/special-nlps/).
+- Salesforce metadata connected to Testsigma. For more information, refer to [creating metadata connections](https://testsigma.com/docs/salesforce-testing/metadata-connections/).
 
 ---
 


### PR DESCRIPTION
Reordered the Salesforce Testsing section & added necessary interlinks in Salesforce documents. 
![image](https://github.com/testsigmahq/testsigma-docs/assets/118433150/43748136-2b40-454f-a87b-540623d6d215)
