### PR TITLE
Updated iOS compatibility issues document

### DIFF
--- a/src/pages/docs/FAQs/web-apps/why-cloud-devices-cannot-access-local-apps.md
+++ b/src/pages/docs/FAQs/web-apps/why-cloud-devices-cannot-access-local-apps.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud based test machines unable to access locally hosted applications"
+title: "Cloud Based Test Machines Unable to Access Locally Hosted Applications"
 metadesc: "During dev the apps are usually hosted on the local Development servers. This article explains why test machines on cloud are unable to access locally hosted apps."
 noindex: false
 order: 24.12
@@ -22,13 +22,19 @@ Perform the following check to confirm that your application under test is not a
 1. Open your application URL in a workstation outside your company network.
 2. If you can access the application from outside your company network (without VPN), you can run tests in our cloud devices. 
 
-<br>
 
 ---
-##**Cloud based Test Labs**
+
+## **Cloud based Test Labs**
 
 Platforms like Testsigma,  Sauce Labs, BrowserStack, etc. provide you with a fully-maintained lab of test machines for cross-browser and device testing. These test machines are hosted on their cloud networks. If your application under test is not publicly available you will not be able to run tests on these machines.
 
 Follow the below steps to test locally hosted applications on our cloud:
-1. If your application is deployed only on your local machine and is not publicly accessible, for example, http://localhost:8080 -> This is a locally hosted application. No one else can access it via the internet. See [how to run your tests for locally hosted applications](https://testsigma.com/docs/runs/test-locally-hosted-applications/).
-2. If your application is behind a firewall, you still have an option to use tunneling mechanisms to connect your application to Testsigma. To do this, first, contact your IT team and then contact Testsigma Support. For any more details on how to access local URLs via Testsigma, please contact Testsigma Support at [support@testsigma.com](mailto:support@testsigma.com)   
+1. If your application is deployed only on your local machine and is not publicly accessible, for example, ```http://localhost:8080```
+   - This is a locally hosted application. No one else can access it via the internet. 
+   - For more information, see [how to run your tests for locally hosted applications](https://testsigma.com/docs/runs/test-locally-hosted-applications/).
+2. If your application is behind a firewall, you still have an option to use tunneling mechanisms to connect your application to Testsigma. 
+   - To do this, first, contact your IT team and then contact Testsigma Support. 
+   - For any more details on how to access local URLs via Testsigma, please contact Testsigma Support at [support@testsigma.com](mailto:support@testsigma.com)   
+
+---

--- a/src/pages/docs/agent/troubleshooting/setup-issues.md
+++ b/src/pages/docs/agent/troubleshooting/setup-issues.md
@@ -1,5 +1,5 @@
 ---
-title: "Troubleshooting Agent startup and registration errors"
+title: "Troubleshooting Agent Startup & Registration Errors"
 metadesc: "Common Agent startup or registration issues and how to troubleshoot them. Learn how to resolve issue if the Agent stops working, or is starts and terminating immediately"
 noindex: false
 order: 11.91
@@ -92,8 +92,8 @@ You will see the following output:![process id](https://s3.amazonaws.com/static-
 
 Once the Testsigma Agent is started, Testsigma Agent web UI is accessible at
 
-- <http://localhost:8383/agent> (HTTP) OR
-- <https://local.testsigmaagent.com:8484/agent/> (HTTPS).
+- ```http://localhost:8383/agent``` (HTTP) OR
+- ```https://local.testsigmaagent.com:8484/agent/``` (HTTPS).
 
 Try accessing the above localhost URLs after starting the agent.
 
@@ -102,7 +102,7 @@ The reason behind doing so is to understand if the agent is accessible and has a
 If the above pages are accessible, proceed to the next step.
 
 
-But if <kbd>https://local.testsigmaagent.com:8484/agent/</kbd> is unreachable but <kbd>http://127.0.0.1:8383/agent/ </kbd>is reachable, the following entry needs to be added to hosts file:
+But if ```https://local.testsigmaagent.com:8484/agent/``` is unreachable but ```http://127.0.0.1:8383/agent/``` is reachable, the following entry needs to be added to hosts file:
 
 `127.0.0.1    local.testsigmaagent.com`
 

--- a/src/pages/docs/getting-started/setup/downloadable-package.md
+++ b/src/pages/docs/getting-started/setup/downloadable-package.md
@@ -91,9 +91,9 @@ Since we have UI components and API server separately we need a single applicati
 Testsigma follows API first approach, all APIs are served from this service. This service contains all APIs and business logic to support the Testsigma UI and all other backend processes. Testsigma Server is a Spring Boot application that runs on port 9090 by default. Make sure that 9090 is free. If you want to change the port follow the steps below.  <br>
    
 - Before changing the ports, stop Nginx, Testsigma Server and Testsigma Agent.<br>
-- Navigate to the Nginx folder from the downloaded Testsigma zip and open nginx.conf. In the text http://localhost:9090 replace the port you would like to use and save it.<br>
+- Navigate to the Nginx folder from the downloaded Testsigma zip and open nginx.conf. In the text ```http://localhost:9090``` replace the port you would like to use and save it.<br>
 - Before starting the Testsigma server set the environment variable TESTSIGMA\_SERVER\_PORT to the port you want<br>
-- Before starting the Testsigma agent, set the environment variable LOCAL\_SERVER\_URL to http://localhost:<port> here you can replace <port> with the port you would like to use.<br>
+- Before starting the Testsigma agent, set the environment variable LOCAL\_SERVER\_URL to ```http://localhost:<port>``` here you can replace <port> with the port you would like to use.<br>
    
 ---
 
@@ -101,7 +101,7 @@ Testsigma follows API first approach, all APIs are served from this service. Thi
 
 Testsigma Agent is a microservice that processes test case data and runs tests on browsers and mobile devices. The Testsigma agent runs on ports 9393 (HTTP) and 9494 (HTTPS) by default. If you want to change these ports, follow the steps below: <br>
 - Before changing the ports, stop Nginx, Testsigma Server, and Testsigma Agent.<br>
-- Before starting the Testsigma server you need to set the environment variable LOCAL\_AGENT\_URL= https://localhost:<http\_port>, here you can replace the <http\_port> with the port you want to use for the agent.<br>
+- Before starting the Testsigma server you need to set the environment variable LOCAL\_AGENT\_URL= ```https://localhost:<http_port>```, here you can replace the <http\_port> with the port you want to use for the agent.<br>
 - Before starting the Testsigma agent you need to set the environment variables TESTSIGMA\_AGENT\_HTTP\_PORT for HTTP port and TESTSIGMA\_AGENT\_HTTPS\_PORT for HTTPS port.<br>
 
 ---
@@ -155,7 +155,7 @@ Testsigma Agent is a microservice that processes test case data and runs tests o
 
 ## **Verifying the installation**
 
-Your Testsigma server should be up and running now. Testsigma server will be accessible at https://local.testsigmaos.com/ui
+Your Testsigma server should be up and running now. Testsigma server will be accessible at ```https://local.testsigmaos.com/ui```
 
 ---
 
@@ -165,7 +165,7 @@ Your Testsigma server should be up and running now. Testsigma server will be acc
  2. Delete the Testsigma Installation folder 
  3. Download the latest version from here https://github.com/testsigmahq/testsigma/releases/latest/
  4. Repeat the steps explained in “Step2: Run Services” section
- 5. Now login to check the updated version of Testsigma Server here  https://local.testsigmaos.com/ui
+ 5. Now login to check the updated version of Testsigma Server here  ```https://local.testsigmaos.com/ui```
 
 ---
 

--- a/src/pages/docs/runs/executing-tests-in-private-grid.md
+++ b/src/pages/docs/runs/executing-tests-in-private-grid.md
@@ -102,7 +102,7 @@ To start the **Private Grid Hub**, open the **Terminal** at **Private Grid** fol
 
 <pre><code>java -jar selenium-server-4.13.0.jar hub</code></pre>
 
-Once the **Private Grid** starts, open http://localhost:4444
+Once the **Private Grid** starts, open ```http://localhost:4444```
 
 To start the Web Nodes, open the new tab on the same Terminal and use the following command:
 

--- a/src/pages/docs/troubleshooting/web-apps/url-not-accessible.md
+++ b/src/pages/docs/troubleshooting/web-apps/url-not-accessible.md
@@ -31,7 +31,7 @@ In the above scenarios, Testsigma's cloud servers will not be able to access the
 
 ### **Follow these steps to automate locally hosted applications:**
 
-1. If your application is deployed only on your local machine and is not publicly accessible, for example, **http://localhost:8080**. This is a locally hosted application. No one else can access it via the internet. For more information, refer the following:
+1. If your application is deployed only on your local machine and is not publicly accessible, for example, ```http://localhost:8080```. This is a locally hosted application. No one else can access it via the internet. For more information, refer the following:
     - [Dry Runs on Local Devices](https://testsigma.com/docs/runs/dry-runs-on-local-devices/) 
     - [Test Plans on Local Devices](https://testsigma.com/docs/runs/test-plans-on-local-devices/)
 
@@ -44,17 +44,17 @@ In the above scenarios, Testsigma's cloud servers will not be able to access the
 
 If you are not able to access URL's from using the extension, you may have one of the below issues:
 
-**What to do for chrome extension error "Not able to record as third-party cookies are blocked by the browser"?**
+1. **What to do for chrome extension error "Not able to record as third-party cookies are blocked by the browser"?**
 
-Go to this URL in Chrome **chrome://settings/cookies** and select **Allow all cookies** or **Block third-party cookies incognito**, you should not see this error post this.
+   **Sol:** Go to this URL in Chrome **chrome://settings/cookies** and select **Allow all cookies** or **Block third-party cookies incognito**, you should not see this error post this.
 
-<iframe src="https://docs.testsigma.com/videos/url-not-accesible/Allow_cookies_or_Block_thirdparty_cookies.mp4" width="300" height="200"></iframe>
+   <iframe src="https://docs.testsigma.com/videos/url-not-accesible/Allow_cookies_or_Block_thirdparty_cookies.mp4" width="300" height="200"></iframe>
 
-**What to do for chrome extensions error "Not able to access local files and urls"?**
+2. **What to do for chrome extensions error "Not able to access local files and urls"?**
 
-Please go to the following Extensions icon in **Chrome > Manage Extenstion > Testsigma Extension > Details** and Toggle on **Allow access to File URL’s**
+   **Sol:** Go to the following Extensions icon in **Chrome > Manage Extenstion > Testsigma Extension > Details** and Toggle on **Allow access to File URL’s**
 
-<iframe src="https://docs.testsigma.com/videos/url-not-accesible/Local_File_access.mp4" width="300" height="200"></iframe>
+   <iframe src="https://docs.testsigma.com/videos/url-not-accesible/Local_File_access.mp4" width="300" height="200"></iframe>
 
 
 ---


### PR DESCRIPTION
Updated iOS compatibility issues document & updated localhost URLs with texts as per SEO suggestions. 
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/a7fdca9a-eba9-4d0f-9cd4-70a3c1cf87fb">

Updated docs where we had local host URLs:
https://testsigma.com/docs/runs/executing-tests-in-private-grid/
https://testsigma.com/docs/agent/troubleshooting/setup-issues/
https://testsigma.com/docs/FAQs/web-apps/why-cloud-devices-cannot-access-local-apps/
https://testsigma.com/docs/getting-started/setup/downloadable-package/
https://testsigma.com/docs/troubleshooting/web-apps/url-not-accessible/