### PR TITLE
Interlinked Refresh Metadata API with Connections

### DIFF
--- a/src/pages/docs/api/examples/trigger-sf-metadata.md
+++ b/src/pages/docs/api/examples/trigger-sf-metadata.md
@@ -61,10 +61,10 @@ When there are changes in metadata, users must refresh it before executing the t
 
 ### **Request fields / Response fields**<br>
 
-- **id:** Salesforce Connection ID<br>
-- **metadataSyncResult:** Status of metadata sync process<br>
-- **metadataSyncType:** Type of metadata sync<br>
-- **salesforceConnectionId:** Salesforce Connection ID<br>
+- **id:** Refresh Trigger ID.<br>
+- **metadataSyncResult:** Status of metadata sync process.<br>
+- **metadataSyncType:** Type of metadata sync.<br>
+- **salesforceConnectionId:** Salesforce Connection ID.<br>
 
 ---
 
@@ -83,8 +83,8 @@ When there are changes in metadata, users must refresh it before executing the t
 
 ### **Request fields / Response fields**<br>
 
-- **status:** Status of metadata sync process<br>
-- **message:** Additional information of sync process<br>
+- **status:** Status of metadata sync process.<br>
+- **message:** Additional information of sync process.<br>
 
 
 ---

--- a/src/pages/docs/salesforce-testing/metadata-connections.md
+++ b/src/pages/docs/salesforce-testing/metadata-connections.md
@@ -112,8 +112,14 @@ To refresh metadata, you have two options:
 1. From the **Dashboard**, go to **SF Connections** and click on **Refresh Metadata**. 
    ![Refresh](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/sfmdref1.png)
 
+
 2. Click on **Refresh Metadata** directly from the dashboard.
    ![Refresh](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/sfmdref2.png)
+
+
+[[info | **NOTE**:]]
+| 
+| You can also refresh metadata using API. *For more details, see [Salesforce Metadata Refresh Using API](https://testsigma.com/docs/api/examples/trigger-sf-metadata/)*.
 
 ---
 


### PR DESCRIPTION
Interlinked Refresh Metadata using API doc with Salesforce Metadata Connections doc.
![Uploading image.png…]()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced Salesforce metadata connection refresh instructions.
	- Added new step for refreshing metadata from the dashboard.
	- Included information about metadata refresh via API with a reference link.
	- Updated descriptions for request and response fields in API documentation for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->