### PR TITLE
Added a documentation for "Apple Pay Automation"

### DIFF
--- a/src/pages/docs/FAQs/mobile-apps/apple-pay-automation.md
+++ b/src/pages/docs/FAQs/mobile-apps/apple-pay-automation.md
@@ -1,0 +1,104 @@
+---
+title: "Apple Pay Automation with Testsigma"
+metadesc: "Apple Pay Automation is complex due to Apple's strict security standards and testing challenges."
+noindex: false
+order: 24.21
+page_id: "Apple Pay Automation with Testsigma"
+warning: false
+contextual_links:
+- type: section
+  name: "Contents"
+- type: link
+  name: "Overview"
+  url: "#overview"
+- type: link
+  name: "Device Compatibility"
+  url: "#device-compatibility"
+- type: link
+  name: "Implementation Process with Testsigma"
+  url: "#implementation-process-with-testsigma"
+- type: link
+  name: "Key Consideration"
+  url: "#key-consideration"
+
+---
+
+---
+
+Apple Pay Automation is a complex process that requires careful implementation due to Apple's rigorous security standards and testing challenges. This guide provides a comprehensive walkthrough of the automation process in Testsigma, key considerations, and implementation steps.
+
+---
+
+## **Device Compatibility**
+
+Apple Pay automation is currently limited to a specific set of devices. Ensure you verify the exact device compatibility before proceeding.
+
+List of compatible devices : 
+
+|Devices Supported for Apple Pay|iOS Version|
+|    :----:   |    :----:   |
+| iPhone 15 | 17 |
+| iPhone 14 | 16 |
+| iPhone 14 Pro | 16 |
+| iPhone 13 Pro Max | 15 |
+| iPhone 13 Pro | 15 |
+| iPhone 13 Mini | 15 |
+| iPhone 13 | 15 |
+| iPhone 11 Pro | 15 |
+| iPhone 11 | 15 |
+| iPhone XR | 15 |
+
+---
+
+## **Implementation Process with Testsigma**
+
+Implementation with TestSigma is simple and straightforward. 
+
+1. Download the addon: Testsigma has an built-in addon to automate this flow, you can download the addon and use the addon inside your test step. The addon screenshot is added below 
+   ![Autopay](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/Auto-pay.png)
+
+2. Use Desired capability: Before you execute the test case, you can use the desired capability listed below and choose the compatible devices shared in the previous list. 
+
+   |Key|Data Type|Value|
+   |    :----:   |    :----:   |    :----:   |
+   | enableApplePay | String | true |
+   | appiumVersion | String | 1.21.0 |
+   | deviceName | String | iPhone 15 |
+   | osVersion | String | 17.0 | 
+
+---
+
+## **Key Consideration**
+
+When defining Apple Pay details, follow these best practices to ensure compatibility with the test environment:
+
+1. **Address Information:**
+   - Only include relevant parameters for the shipping and billing addresses.
+   - Remove parameters that are not applicable. For instance, if your test address does not include a province value, exclude the `province` parameter from your script.
+
+2. **Geographical Codes:**
+   - Use the appropriate geographical code based on your address format and what the device accepts.
+   - Choose from one of the following: `postalCode`, `postCode`, or `zip`.
+
+3. **Phone Number Format:**
+   - Include the country code prefix with the `+` character.
+   - Examples of valid formats include:
+      - `+1-212-456-7890`
+      - `+12124567890`
+   
+4. **Session Failures:**
+   - If your session fails due to incorrect address parameters, adjust the geographical code accordingly.
+   - For instance, if your address uses the zip parameter but the device expects `postalCode` or `postCode`, modify the script and re-run the test to identify the accepted format.
+
+### **Regional Limitations for Apple Pay Testing**
+
+On testsigma iOS devices, testing with Apple Pay is limited to the following regions:
+
+|Geography|Country|
+|    :----:   |    :----:   |
+| North America | United States, Canada |
+| Europe | France, Ireland, Italy, Spain, UK, Germany |
+| Asia | China Mainland, Hong Kong, Taiwan, Japan, Russia, Singapore | 
+| Australia | Australia, New Zealand | 
+
+---

--- a/src/pages/docs/FAQs/mobile-apps/apple-pay-automation.md
+++ b/src/pages/docs/FAQs/mobile-apps/apple-pay-automation.md
@@ -1,6 +1,6 @@
 ---
 title: "Apple Pay Automation with Testsigma"
-metadesc: "Apple Pay Automation is complex due to Apple's strict security standards and testing challenges."
+metadesc: "Apple Pay Automation is complex due to Apple's strict security standards and testing challenges | Learn about Apple Pay Automation with Testsigma application"
 noindex: false
 order: 24.21
 page_id: "Apple Pay Automation with Testsigma"
@@ -25,7 +25,7 @@ contextual_links:
 
 ---
 
-Apple Pay Automation is a complex process that requires careful implementation due to Apple's rigorous security standards and testing challenges. This guide provides a comprehensive walkthrough of the automation process in Testsigma, key considerations, and implementation steps.
+Apple Pay Automation is a complex process that requires careful implementation due to Apple's rigorous security standards and testing challenges. This article discusses the automation process for Apple Pay, including key considerations and implementation steps.
 
 ---
 
@@ -57,7 +57,7 @@ Implementation with TestSigma is simple and straightforward.
 1. Download the addon: Testsigma has an built-in addon to automate this flow, you can download the addon and use the addon inside your test step. The addon screenshot is added below 
    ![Autopay](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/Auto-pay.png)
 
-2. Use Desired capability: Before you execute the test case, you can use the desired capability listed below and choose the compatible devices shared in the previous list. 
+2. Add Desired capability: Before you execute the test case, you can add the desired capability listed below and choose the compatible devices shared in the previous list. 
 
    |Key|Data Type|Value|
    |    :----:   |    :----:   |    :----:   |

--- a/src/pages/docs/integrations/test-management/qtest.md
+++ b/src/pages/docs/integrations/test-management/qtest.md
@@ -57,8 +57,9 @@ qTest is a manual test management tool. With qTest integration in Testsigma, you
    ![Save qTest Details](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/qTest_Details_Save.png)
 
 [[info | **NOTE**:]]
-| You must obtain the **Bearer Token** from the **Download qTest Resources** page. *For more information, see [qTest Documentation](https://documentation.tricentis.com/qtest/od/en/content/overview/download_qtest_resources_page.htm).*
+| 1.  You must obtain the **Bearer Token** from the **Download qTest Resources** page. *For more information, see [qTest Documentation](https://documentation.tricentis.com/qtest/od/en/content/overview/download_qtest_resources_page.htm).*
 | ![Bearer Token](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/qTest_BearerToken.png)
+| 2. Please copy the token except **Bearer**. 
 
 
 ---


### PR DESCRIPTION
Added a documentation for "Apple Pay Automation" as per the ticket https://testsigma.atlassian.net/browse/IDEA-2270
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f3db8118-1d14-4cbf-9168-e0c8d18ef8ae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced a comprehensive guide for automating Apple Pay with Testsigma, outlining detailed steps, device compatibility, implementation best practices, and regional testing considerations.
  - Refined the qTest integration instructions by adding clear, numbered steps for acquiring and processing the Bearer Token to enhance clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->