### PR TITLE
Added a new doc for Manage Access

### DIFF
--- a/src/left-nav-title.json
+++ b/src/left-nav-title.json
@@ -701,5 +701,6 @@
   "testrail": {"/docs/integrations/test-management/testrail/": "TestRail"},
   "label-management": {"/docs/test-cases/manage/label-management/": "Label Management" },
   "mobile-accessibility-testing": {"/docs/accessibility-testing/mobile-accessibility-testing/": "Accessibility Testing for Android & iOS"},
-  "live-editor": {"/docs/live-editor/": "Testsigma Lite (Live Editor)" }
+  "live-editor": {"/docs/live-editor/": "Testsigma Lite (Live Editor)" },
+  "manage-access": {"/docs/configuration/manage-access/": "Manage Access"}
 }

--- a/src/pages/docs/configuration/manage-access.md
+++ b/src/pages/docs/configuration/manage-access.md
@@ -1,0 +1,92 @@
+---
+title: "Manage Access: Grant/Revoke Permissions"
+order: 19.8
+page_id: "Manage Access"
+metadesc: "Grant and revoke access to Testsigma support | Learn how to securely share access, view activity logs, & maintain full control over your account data"
+noindex: false
+search_keyword: ""
+warning: false
+contextual_links:
+- type: section
+  name: "Contents"
+- type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
+  name: "Interactive Demo"
+  url: "#interactive demo"
+- type: link
+  name: "Managing Access"
+  url: "#managing-access"
+- type: link
+  name: "Security and Privacy"
+  url: "#security-and-privacy"
+- type: link
+  name: "View Access Logs"
+  url: "#view-access-logs"
+---
+
+---
+
+Admin in the Testsigma account can grant temporary access to the Testsigma Support team for diagnosing and resolving support related issues. This article discusses how to authorize and revoke support access.
+
+[[info | **NOTE**:]]
+| Only users with **Admin** access can authorize or revoke support access.
+
+---
+
+> ## **Prerequisites**
+> 
+> Before you begin, ensure you have **Admin** access to your Testsigma account.
+
+---
+
+## **Interactive Demo**
+
+<div>
+  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
+  <div class="sl-embed" style="position:relative;padding-bottom:calc(57.41% + 25px);width:100%;height:0;transform:scale(1)">
+    <iframe loading="lazy" class="sl-demo" src="https://app.storylane.io/demo/nis6mcirsivm?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
+  </div>
+</div>
+
+---
+
+## **Managing Access** 
+
+1. From the **Dashboard**, go to **Settings > Admin Settings > Manage Access**.
+
+2. In the **Manage Access** section, click **Allow Access**.
+
+3. Select the **Access Type** from the available options.
+
+4. In the **Describe the Issue** field, briefly explain the reason for providing access.
+
+5. Select the consent checkbox and click **Submit** to grant access.
+
+6. View the **Current Status** and **Access Expiry** information on the same page.
+
+7. Click **Manage** to update or revoke access as needed.
+
+---
+
+## **Security and Privacy**
+
+- Testsigma logs all support actions under the user **guest@testsigma.com**, ensuring full traceability.
+
+- Access is strictly limited to the scope necessary for troubleshooting and issue resolution.
+
+- The support team follows industry standard security protocols and best practices at all times.
+
+- You retain full control over access and can revoke it anytime based on your needs.
+
+---
+
+## **View Access Logs**
+
+- View access-related logs by clicking **Activity** in the **Utility Panel**. The system stores logs for 3 years.
+
+- You can also view logs in the relevant test cases, elements, test suites, and test plans for actions performed by **Testsigma Guest**.
+
+
+---


### PR DESCRIPTION
Added a new doc for granting/revoking access to Testsigma support
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/1288b9c0-fefb-4751-b57e-1c0cb1bc9ef5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new documentation page detailing how Admin users can grant or revoke temporary support access for troubleshooting, including step-by-step instructions, security information, and access log guidance.
- **Documentation**
  - Updated navigation to include the new "Manage Access" documentation page for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->