### PR TITLE
Removed the gatsby template siteMetaTile

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -29,7 +29,6 @@ function SEO({
       query {
         site {
           siteMetadata {
-            title
             description
             author
           }
@@ -76,7 +75,6 @@ function SEO({
           lang,
         }}
         title={title}
-        titleTemplate={`%s | ${site.siteMetadata.title}`}
         meta={[
           {
             name: 'description',


### PR DESCRIPTION
- Removed the gatsby template siteMetaTile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated page titles to no longer append the site title automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->