### PR TITLE
Added GenAI docs for Figma & Jira (Mobile Apps)

### DIFF
--- a/src/left-nav-title.json
+++ b/src/left-nav-title.json
@@ -707,5 +707,6 @@
   "selective-elements": {"/docs/desktop-automation/selective-elements/": "Selective Element Recorder"},
   "batch-elements": {"/docs/desktop-automation/batch-elements/": "Batch Element Recorder"},
   "selective-element-recorder": {"/docs/sap-automation/selective-element-recorder/": "Selective Element Recorder"},
-  "batch-element-recorder": {"/docs/sap-automation/batch-element-recorder/": "Batch Element Recorder"}
+  "batch-element-recorder": {"/docs/sap-automation/batch-element-recorder/": "Batch Element Recorder"},
+  "generate-tests-from-user-actions": {"/docs/genai-capabilities/generate-tests-from-user-actions/": "Generate Tests from User Actions"}
 }

--- a/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
@@ -174,7 +174,7 @@ A frame inside a page or a section represents a screen of web or mobile app.
 
 1. From the left navigation bar, go to **Create Tests > Test Cases**. 
 
-2. Click **Copilot** and then select **Generate Test Cases** from the drop-down menu. 
+2. Click **Copilot** and then select **Generate Test Cases** from the dropdown menu. 
 
 3. In the **Generate Test Cases** screen, select **Figma Designs**.
 
@@ -194,7 +194,7 @@ A frame inside a page or a section represents a screen of web or mobile app.
 
 7. Select the test cases you want to save, and click **Save Test Cases**.
 
-8. You’ll be redirected to the Test Cases page, where the generated test cases appear under the **AI Generated Feature / Scenario**.
+8. You’ll be redirected to the Test Cases page, where the generated test cases appear under the **AI-Generated Feature / Scenario**.
 
 <br>
 
@@ -228,7 +228,7 @@ A frame inside a page or a section represents a screen of web or mobile app.
 
 7. Select the test cases you want to save, and click **Save Test Cases**.
 
-8. You’ll be redirected to the Test Cases page, where the generated test cases appear under the **AI Generated Feature / Scenario**.
+8. You’ll be redirected to the Test Cases page, where the generated test cases appear under the **AI-Generated Feature / Scenario**.
 
 <br>
 

--- a/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
@@ -22,11 +22,17 @@ contextual_links:
   name: "Components of Figma"
   url: "#components-of-figma"
 - type: link
-  name: "Steps to Generate Test Cases from Figma Designs"
-  url: "#steps-to-generate-test-cases-from-figma-designs"
+  name: "Generate Test Cases for Web Apps"
+  url: "#generate-test-cases-for-web-apps"
 - type: link
-  name: "Interactive Demo"
-  url: "#interactive-demo"
+  name: "Interactive Demo for Web Apps"
+  url: "#interactive-demo-for-web-apps"
+- type: link
+  name: "Generate Test Cases for Android & iOS Apps"
+  url: "#generate-test-cases-for-android--ios-apps"
+- type: link
+  name: "Interactive Demo for Android & iOS Apps"
+  url: "#interactive-demo-for-android--ios-apps"
 ---
 
 ---
@@ -164,7 +170,7 @@ A frame inside a page or a section represents a screen of web or mobile app.
 
 ---
 
-## **Steps to Generate Test Cases from Figma Designs**
+## **Generate Test Cases for Web Apps**
 
 1. From the left navigation bar, go to **Create Tests > Test Cases**. 
 
@@ -172,35 +178,27 @@ A frame inside a page or a section represents a screen of web or mobile app.
 
 3. In the **Generate Test Cases** screen, select **Figma Designs**.
 
-4. In the **Add Figma Designs** overlay, the Copilot automatically selects a project. You can expand the **Project** field and select the required project. 
-
-5. Select the required file from the **Figma File** drop-down menu. 
-
-6. Select the required page from the **Page** drop-down menu. 
-
-7. Select the required section from the **Section** field drop-down menu. 
+4. In the **Add Figma Designs** section, 
+   - Select a **Project**, **Figma File**, **Section** and **Page** from the respective dropdown menus.
+   - Click **+ Select Frames**, select the required frames in the **Select Frames** screen, and click **Add Frames**.
+   - If you want to remove all the selections that you have made, click **Clear Selection**. 
 
 [[info | **NOTE**:]]
-| If the selected page has no sections, you can directly select the frames.
+| - If the selected page has no sections, you can directly select the frames.
+| 
+| - The maximum limit for selecting frames is 10. 
 
-8. In the **Frames** field, click **+ Select Frames**.
+5. In the prompt field, enter the required details, and click the **Play** button.
 
-9. Select the required frames in the **Select Frames** screen and click **Add Frames**.  
+6. Wait for Testsigma to generate the test cases with the test steps.
 
-If you want to remove all the selections that you have made, click **Clear Selection**. 
+7. Select the test cases you want to save, and click **Save Test Cases**.
 
-[[info | **NOTE**:]]
-| The maximum limit for selecting frames is 10. 
+8. You’ll be redirected to the Test Cases page, where the generated test cases appear under the **AI Generated Feature / Scenario**.
 
-10.  Enter a prompt and click **Send**. 
+<br>
 
-11.  Select the test cases you want to add to the test case list and select **Save Test Cases**.
-
----
-
-## **Interactive Demo**
-
-Try this interactive demo to learn how to generate test cases from Figma designs!
+## **Interactive Demo for Web Apps**
 
 <div>
   <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
@@ -209,5 +207,38 @@ Try this interactive demo to learn how to generate test cases from Figma designs
   </div>
 </div>
 
+
+---
+
+## **Generate Test Cases for Android & iOS Apps** 
+
+1. From the left navigation bar, go to **Create Tests > Test Cases**.
+
+2. Click **Copilot**, and then select **Generate Test Cases** from the dropdown menu.
+
+3. In the **Generate Test Cases** page, select **Figma Designs** as input source. 
+
+4. In the **Add Figma Designs** section, 
+   - Select a **Project**, **Figma File**, **Section** and **Page** from the respective dropdown menus.
+   - Click **+ Select Frames**, select the required frames in the **Select Frames** screen, and click **Add Frames**.
+
+5. In the prompt field, enter the required details, and click the **Play** button.
+
+6. Wait for Testsigma to generate the test cases with the test steps.
+
+7. Select the test cases you want to save, and click **Save Test Cases**.
+
+8. You’ll be redirected to the Test Cases page, where the generated test cases appear under the **AI Generated Feature / Scenario**.
+
+<br>
+
+## **Interactive Demo for Android & iOS Apps**
+
+<div>
+  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
+  <div class="sl-embed" style="position:relative;padding-bottom:calc(57.41% + 25px);width:100%;height:0;transform:scale(1)">
+    <iframe loading="lazy" class="sl-demo" src="https://app.storylane.io/demo/gben4vh6j94t?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
+  </div>
+</div>
 
 ---

--- a/src/pages/docs/genai-capabilities/generate-tests-from-requirements.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-requirements.md
@@ -13,8 +13,14 @@ contextual_links:
   name: "Prerequisites"
   url: "#prerequisites"
 - type: link
-  name: "Steps to Generate Test Cases from Requirements"
-  url: "#steps-to-generate-test-cases-from-requirements"
+  name: "Generate Test Cases for Web Apps"
+  url: "#generate-test-cases-for-web-apps"
+- type: link
+  name: "Generate Test Cases for Android & iOS Apps"
+  url: "#generate-test-cases-for-android--ios-apps"
+- type: link
+  name: "Interactive Demo for Android & iOS Apps"
+  url: "#interactive-demo-for-android--ios-apps"
 ---
 
 ---
@@ -29,7 +35,7 @@ With Testsigma, you can create test cases directly from Jira stories and epics b
 
 ---
 
-## **Steps to Generate Test Cases from Requirements**
+## **Generate Test Cases for Web Apps**
 
 1. From the left navigation bar, go to **Create Tests > Test Cases**.
 
@@ -55,5 +61,39 @@ With Testsigma, you can create test cases directly from Jira stories and epics b
 | 
 | ![API Steps Checkbox](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/SF_Generate_Steps_Jira.png)
 
+---
+
+## **Generate Test Cases for Android & iOS Apps**
+
+1. From the left navigation bar, go to **Create Tests > Test Cases**.
+
+2. Click **Copilot**, and then select **Generate Test Cases** from the dropdown menu.
+
+3. In the **Generate Test Cases** page, select **Jira Requirements** as input source. 
+
+4. In the **Add Jira Stories** section, 
+   - Select a **Jira Project** from the dropdown menu.
+   - Under **Issue Type**, select either **Epic** or **Story**:
+      - If you select **Epic**, choose the stories for which you want to generate test cases.
+      - If you select **Story**, choose all the stories for which you want to generate test cases.
+
+5. In the prompt field, enter the required details, and click the **Play** button.
+
+6. Wait for Testsigma to generate the test cases with the test steps.
+
+7. Select the test cases you want to save, and click **Save Test Cases**.
+
+8. You’ll be redirected to the **Test Cases** page, where the generated test cases appear under the **AI Generated Feature / Scenario**.
+
+<br>
+
+## **Interactive Demo for Android & iOS Apps**
+
+<div>
+  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
+  <div class="sl-embed" style="position:relative;padding-bottom:calc(57.41% + 25px);width:100%;height:0;transform:scale(1)">
+    <iframe loading="lazy" class="sl-demo" src="https://app.storylane.io/demo/uj3otprgm4zj?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
+  </div>
+</div>
 
 ---

--- a/src/pages/docs/genai-capabilities/mobile-copilot.md
+++ b/src/pages/docs/genai-capabilities/mobile-copilot.md
@@ -1,5 +1,5 @@
 ---
-title: "Testsigma Copilot for Mobile Apps (New ✨)"
+title: "Testsigma Copilot for Mobile Apps"
 page_title: "Testsigma Copilot for Mobile Applications"
 metadesc: "In Testsigma, you can create test cases for Mobile Applications using Testsigma Copilot | Learn how to create test cases for Mobile Applications using GenAI capabilities"
 noindex: false

--- a/src/pages/docs/genai-capabilities/overview.md
+++ b/src/pages/docs/genai-capabilities/overview.md
@@ -40,11 +40,16 @@ Testsigma is revolutionizing test case creation using GenAI Capabilities. You ca
 
 - [Generate Test Scenarios from User Actions](https://testsigma.com/docs/genai-capabilities/generate-tests-from-user-actions/)
 
-- [Generate Test Scenarios from Requirements](https://testsigma.com/docs/genai-capabilities/generate-tests-from-requirements/)
+- [Generate Test Scenarios from Requirements (Web)](https://testsigma.com/docs/genai-capabilities/generate-tests-from-requirements/)
+
+- [Generate Test Scenarios from Requirements (Android & iOS)](https://testsigma.com/docs/genai-capabilities/generate-tests-from-requirements/)
 
 - [Generate Test Scenarios from Swagger Schema](https://testsigma.com/docs/genai-capabilities/generate-tests-from-swagger/)
 
-- [Generate Tests from Figma Designs](https://testsigma.com/docs/genai-capabilities/generate-tests-from-figma-designs/)
+- [Generate Tests from Figma Designs (Web)](https://testsigma.com/docs/genai-capabilities/generate-tests-from-figma-designs/#generate-test-cases-for-web-apps)
+
+- [Generate Tests from Figma Designs (Android & iOS)](https://testsigma.com/docs/genai-capabilities/generate-tests-from-figma-designs/#generate-test-cases-for-android--ios-apps)
+
 
 ---
 

--- a/src/pages/docs/reports/runs/custom-pdf-report.md
+++ b/src/pages/docs/reports/runs/custom-pdf-report.md
@@ -177,99 +177,84 @@ Replace the placeholders with your actual values:
 
 List of configurable preferences to tailor your PDF reports according to your needs.
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 20px;
-        }
-        table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        th, td {
-            border: 1px solid #dddddd;
-            text-align: left;
-            padding: 8px;
-        }
-        th {
-            background-color: #f2f2f2;
-        }
-        tr:nth-child(even) {
-            background-color: #f9f9f9;
-        }
-        caption {
-            font-weight: bold;
-            margin: 10px 0;
-        }
-    </style>
-</head>
-<body>
-    <table>
-        <thead>
-            <tr>
-                <th>Preference</th>
-                <th>Description</th>
-                <th>Allowed Values</th>
-                <th>Input Type</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>config.preference.resultLevel</td>
-                <td>Defines the level of detail for the report</td>
-                <td>PLAN, MACHINE, SUITE, CASE</td>
-                <td>Single value</td>
-            </tr>
-            <tr>
-                <td>config.preference.step</td>
-                <td>Specifies which steps to include in the report</td>
-                <td>PASSED, FAILED, EXECUTED, NOT_EXECUTED, ALL, NONE</td>
-                <td>Single value</td>
-            </tr>
-            <tr>
-                <td>config.preference.screenshot</td>
-                <td>Indicates which screenshots to include</td>
-                <td>PASSED, FAILED, ALL, NONE</td>
-                <td>Single value</td>
-            </tr>
-            <tr>
-                <td>config.preference.visualDifference</td>
-                <td>Specifies which visual screenshots to include</td>
-                <td>PASSED, FAILED, ALL, NONE</td>
-                <td>Single value</td>
-            </tr>
-            <tr>
-                <td>config.preference.summaryFields</td>
-                <td>Fields to display in the report summary</td>
-                <td>name, executedBy, environment, testPlanName, testDeviceName, testSuiteName, result, buildNo, runId, screenshotCapturedFor, screenshotMode</td>
-                <td>Multi-value (comma-separated)</td>
-            </tr>
-            <tr>
-                <td>config.preference.caseListColumns</td>
-                <td>Columns to show in the test case list</td>
-                <td>ETF, testSuite, testMachine, assignee, reviewer</td>
-                <td>Multi-value (comma-separated)</td>
-            </tr>
-            <tr>
-                <td>config.preference.caseDetailsHeaders</td>
-                <td>Columns to show in case details headers</td>
-                <td>testCaseName, testSuiteName</td>
-                <td>Multi-value (comma-separated)</td>
-            </tr>
-            <tr>
-                <td>config.preference.stepListColumns</td>
-                <td>Columns to show in the step list</td>
-                <td>reasonForFailure, testDataDetails, duration, apiResponseUrl</td>
-                <td>Multi-value (comma-separated)</td>
-            </tr>
-        </tbody>
-    </table>
-</body>
-</html>
+<style>
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: Arial, sans-serif;
+    }
+    th, td {
+        border: 1px solid #dddddd;
+        text-align: left;
+        padding: 8px;
+    }
+    th {
+        background-color: #f2f2f2;
+    }
+    tr:nth-child(even) {
+        background-color: #f9f9f9;
+    }
+</style>
+
+<table>
+    <thead>
+        <tr>
+            <th>Preference</th>
+            <th>Description</th>
+            <th>Allowed Values</th>
+            <th>Input Type</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>config.preference.resultLevel</td>
+            <td>Defines the level of detail for the report</td>
+            <td>PLAN, MACHINE, SUITE, CASE</td>
+            <td>Single value</td>
+        </tr>
+        <tr>
+            <td>config.preference.step</td>
+            <td>Specifies which steps to include in the report</td>
+            <td>PASSED, FAILED, EXECUTED, NOT_EXECUTED, ALL, NONE</td>
+            <td>Single value</td>
+        </tr>
+        <tr>
+            <td>config.preference.screenshot</td>
+            <td>Indicates which screenshots to include</td>
+            <td>PASSED, FAILED, ALL, NONE</td>
+            <td>Single value</td>
+        </tr>
+        <tr>
+            <td>config.preference.visualDifference</td>
+            <td>Specifies which visual screenshots to include</td>
+            <td>PASSED, FAILED, ALL, NONE</td>
+            <td>Single value</td>
+        </tr>
+        <tr>
+            <td>config.preference.summaryFields</td>
+            <td>Fields to display in the report summary</td>
+            <td>name, executedBy, environment, testPlanName, testDeviceName, testSuiteName, result, buildNo, runId, screenshotCapturedFor, screenshotMode</td>
+            <td>Multi-value (comma-separated)</td>
+        </tr>
+        <tr>
+            <td>config.preference.caseListColumns</td>
+            <td>Columns to show in the test case list</td>
+            <td>ETF, testSuite, testMachine, assignee, reviewer</td>
+            <td>Multi-value (comma-separated)</td>
+        </tr>
+        <tr>
+            <td>config.preference.caseDetailsHeaders</td>
+            <td>Columns to show in case details headers</td>
+            <td>testCaseName, testSuiteName</td>
+            <td>Multi-value (comma-separated)</td>
+        </tr>
+        <tr>
+            <td>config.preference.stepListColumns</td>
+            <td>Columns to show in the step list</td>
+            <td>reasonForFailure, testDataDetails, duration, apiResponseUrl</td>
+            <td>Multi-value (comma-separated)</td>
+        </tr>
+    </tbody>
+</table>
 
 ---

--- a/src/pages/docs/test-cases/manage/features-and-scenarios.md
+++ b/src/pages/docs/test-cases/manage/features-and-scenarios.md
@@ -1,5 +1,5 @@
 ---
-title: "Organizing Test Cases in Folders (✨ New)"
+title: "Organizing Test Cases in Folders"
 pagetitle: "Organize Test Cases"
 metadesc: "Effortlessly organize test cases by features & scenarios, which provides a complete view of test coverage. The folder structure also simplifies the navigation."
 noindex: false


### PR DESCRIPTION
Added new sections in generating test cases for android and iOS using Jira stories & Figma designs docs.
<img width="1697" alt="image" src="https://github.com/user-attachments/assets/073ebacb-886e-4df2-8d21-73b7f5a1515b" />
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/d4199438-07ac-4fee-a6e1-d4eb4c0e5d02" />

Also, removed HTML block in Customize Reports docs since it had SEO Impact. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified instructions for generating test cases from Figma designs and requirements, now with separate, detailed steps and interactive demos for both web and Android/iOS apps.
  - Updated navigation and contextual links to distinguish between web and mobile platforms for test generation features.
  - Simplified and focused the custom PDF report documentation snippet by removing unnecessary HTML wrappers.
  - Removed "New" labels from relevant documentation titles for a cleaner appearance.

- **Chores**
  - Added a new navigation entry for "Generate Tests from User Actions" in the left navigation menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->