### PR TITLE
Fixed name in the banner in docs home

### DIFF
--- a/src/pages/docs/index.jsx
+++ b/src/pages/docs/index.jsx
@@ -16,8 +16,9 @@ const IndexContent = () => {
     <>
       <div className='w-full md:px-16 home-page_banner'>
         <h1 className='text-4xl font-bold'>
-          Testsigma Knowledge and Documentation Support | Testsigma
+          Testsigma Documentation & Support
         </h1>
+        <br />
         <br />
         <span className='text-base font-normal'>
           SETUP | WRITE | RUN | MAINTAIN | INTEGRATE | EXTEND


### PR DESCRIPTION
Fixed name in the banner in docs hoome.
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/a33eec71-9edc-4015-a548-4b886c322189" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the main heading text for improved clarity.
  - Increased vertical spacing below the main heading for better visual separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->