### PR TITLE
Added documents for "Import Test Cases"

### DIFF
--- a/src/pages/docs/test-cases/manage/add-test-cases-for-mobile-web-app.md
+++ b/src/pages/docs/test-cases/manage/add-test-cases-for-mobile-web-app.md
@@ -2,7 +2,7 @@
 title: "Test Cases for Mobile Web Application"
 metadesc: "This document explains how to create Test Cases for Mobile Web Application in detail | Learn how to write test cases for Mobile Web Application in Testsigma"
 noindex: false
-order: 4.18
+order: 4.191
 page_id: "How to create Test cases for Mobile Web Application?"
 warning: false
 contextual_links:

--- a/src/pages/docs/test-cases/manage/custom-fields.md
+++ b/src/pages/docs/test-cases/manage/custom-fields.md
@@ -3,7 +3,7 @@ title: "Custom Fields for Test Cases"
 pagetitle: "Custom Fields for Test Cases"
 metadesc: "Create custom fields to enter specific details, add them to your test cases, and filter test cases as per the available custom fields."
 noindex: false
-order: 4.19
+order: 4.192
 page_id: "Custom Fields"
 warning: false
 contextual_links:

--- a/src/pages/docs/test-cases/manage/import-export.md
+++ b/src/pages/docs/test-cases/manage/import-export.md
@@ -1,9 +1,10 @@
 ---
-title: "Import and Export Test Cases"
-metadesc: "You can use test case import and export to populate a new Testsigma project with previously built test cases | Learn how to import and export test cases in Testsigma"
+title: "Import Test Cases"
+page_title: "Import Test Cases"
+metadesc: "Import test cases between Testsigma projects by matching application types in both source and target projects to ensure full compatibility and smooth transfer process."
 noindex: false
 order: 4.14
-page_id: "Import and Export Test Cases"
+page_id: "import-test-cases"
 warning: false
 contextual_links:
 - type: section
@@ -12,11 +13,8 @@ contextual_links:
   name: "Prerequisites"
   url: "#prerequisites"
 - type: link
-  name: "Import file format"
-  url: "#import-file-format"
-- type: link
-  name: "Steps to Export Test Cases"
-  url: "#steps-to-export-test-cases"
+  name: "Interactive Demo"
+  url: "#interactive-demo"
 - type: link
   name: "Steps to Import Test Cases"
   url: "#steps-to-import-test-cases"
@@ -24,86 +22,73 @@ contextual_links:
 
 ---
 
-You can easily use test case import and export to populate a new Testsigma project with previously built test cases or perform bulk-update on the Test Cases. This article discusses how to import and export test cases in Testsigma.
+You can use test case import to move test cases from one project to another within Testsigma. Test cases can only be imported from one application type to the same application type in the target project. This article explains how to import test cases between projects in Testsigma.
 
 ---
 
 > ## **Prerequisites**
 > 
 > - You should know how to [Manage Projects](https://testsigma.com/docs/projects/overview/).
+> 
 
 ---
 
-## **Steps to Export Test Cases**
-1. Navigate to **Settings > Imports & Exports**, and click on **Export**.
-![Imports & Exports](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/EXPORTTCS.png)
+## **Interactive Demo**
 
-2. On **Export** prompt, 
-    - Select the **Project**, **Application** and **Version** from which you want to export test cases.
-    ![Select Project, Apps, Version](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/exportprompttcs.png)
-    - Check the models you want to export.
-    ![Export Models](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/exportmodelstcs.png)
-    - Click on **Start export**.
-    ![Start Exports](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/startexporttcs.png)
-
-You’ll receive mail with an exported data file. Download the file to import data on targeted applications and versions. Alternatively, you can also download the file by clicking on the **Kabab Menu** & **Download import data**.
-![Kebab Menu & Download](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/kebabtcs.png)
-
-Here’s a quick GIF demonstrating how to export test cases. 
-![Export](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/ExportTCs.gif)
-
-## **Import File Format**
-
-The Import file has the following Columns:
-
-| Column Name | Description |
-| :----------- |:----------- |
-| ID | The id of the Test Case when it is exported (Only applicable in case of exported Test Cases) |
-| UUID | The unique identifier of the Test Case when it is exported (Only applicable in case of exported Test Cases) |
-| Testcase Name | Name of the Test Case |
-| Testcase Type | Type of the Test Case |
-| Priority | Priority of the Test Case |
-| Manual | Whether it is a Manual Test Case or Automated Test Case |
-| Created By | Email of the User who created |
-|Updated At | Date and Time of update    |
-|Updated By | Email of the User who updated |
-|PreRequisite | Name of Prerequisite Test Case |
-|Assignee | Email of the User to whom the Test Case is assigned |
-|TestData | Name of Test Data Profile |
-|Status | Status of the Test Case |
-|Is DataDriven | Test Case is data-driven or not |
-|DataSet | DataSet name if the data-driven toggle is turned off |
-|Index | Index of Test Case |
-|Requirement Name | Name of Requirement mapped to the Test Case |
-|Tags | Labels for the Test Case |
-|Is Step Group | Whether it is a Step Group or a Test Case |
-
-[[info | Note:]]
-|A Sample Test Case Import Template file has been provided in the Test Case Import dialog
+<div>
+  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
+  <div class="sl-embed" style="position:relative;padding-bottom:calc(50.81% + 25px);width:100%;height:0;transform:scale(1)">
+    <iframe loading="lazy" class="sl-demo" src="https://app.storylane.io/demo/s7exwjyz2fqt?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
+  </div>
+</div>
 
 ---
 
 ## **Steps to Import Test Cases**
-1. Navigate to **Settings > Imports & Exports**, and click on **Import**.
-![Imports & Exports](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/importexporttcs.png)
 
-2. On **Import** prompt, 
-    - Click on **Select File to Import** and choose the file from which you want to import test cases.
-    ![Select File](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/selectfileimextcs.png)
-    - Select the **Project, Application** and **Version** in which you want to import test cases.
-    ![Import Models](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/importmodels.png)
-    - Check the models you want to import.
-    ![Start Import](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/startimporttcs.png)
-    - Click on **Start import**.
-    ![Start Import Button](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/fileimpexptcs.png)
+1. From the left navigation bar, navigate to **Create Tests > Test Cases**.
 
-Navigate to **Project > Create Tests > Test Cases** to see all the imported test cases. 
+2. In the **Test Cases Explorer** section, click the ellipse icon and click **Import**.
 
-Here’s a quick GIF demonstrating how to import test cases. 
-![Import GIF](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/Importtcs.gif)
+3. In the **Import Artefacts** screen, under the **Select Source** tab:
+    
+    - Choose the source **Project**.
+    - Choose the **Application Name**.
+    - Choose the **Version**.
+
+4. Click **Next**.
 
 [[info | **NOTE**:]]
-|- If you are trying to update the Test Cases using Import/Export, make sure to keep the ID and UUID column intact so that the correct Test Case gets updated while importing back. You may change the other fields as required.
-|- If you are trying to create new Test Cases in bulk, make sure to clear both the ID and UUID columns.
+| - When importing test cases from a web application in the current project, they can only be moved to a web application in the destination project. Moving them to a different application type is not supported.
+
+5. In the **Select Artefacts** tab, choose the test cases, step groups, elements, test data profiles, environment variables, and uploads you want to import.
+
+[[info | **NOTE**:]]
+| - When you select a test case, all associated step groups, elements, test data profiles, environment variables, and uploads are automatically selected.
+
+6. To include artefacts not linked to the selected test cases, go to the relevant tab (e.g., Elements, Step Groups), enable the **Show unlinked (artefact)** toggle, and select the required ones. 
+
+7. You can enable the **Show selected** toggle to review your selections in each artefact tab.
+
+8. Click **Proceed to Import**.
+
+9. In the **Start Import** tab, all selected artefacts will be listed.
+
+[[info | **NOTE**:]]
+| - If the test case doesn’t exist in the destination project, it will be marked with a New status.
+| - If the test case already exists with no changes, it will show as No Change.
+| - If the test case exists but has been modified, it will show as an Override.
+
+10. Click **Confirm**.
+
+11. In the **Create a Save Point?** dialog, enter a name, and click **Start Importing**.
+
+[[info | **NOTE**:]]
+| - Before starting the import, a save point will be created to help you easily revert to the current version if needed.
+| - Please wait until the import process is complete. Interrupting it may lead to data loss.
+| - It’s recommended to import a smaller amount of data at a time, as larger imports may take longer to complete.
+| - A maximum of 10 save points can be stored at any given time.
+
+12. Click **Done**. 
 
 ---

--- a/src/pages/docs/test-cases/manage/import-from-yaml-or-git.md
+++ b/src/pages/docs/test-cases/manage/import-from-yaml-or-git.md
@@ -3,7 +3,7 @@ title: "Import Test Project Test Cases"
 pagetitle: "Start Importing Test Cases from YAML/GIT with Ease"
 metadesc: "Seamlessly transfer projects from Test Project using YAML/GIT in Testsigma to learn how to improve your test automation workflow for efficient testing."
 noindex: false
-order: 4.15
+order: 4.17
 page_id: "Import Test Cases from YAML/GIT"
 warning: false
 contextual_links:

--- a/src/pages/docs/test-cases/manage/import-postman-to-testsigma.md
+++ b/src/pages/docs/test-cases/manage/import-postman-to-testsigma.md
@@ -3,7 +3,7 @@ title: "Importing Postman Collections and Environments"
 pagetitle: "Effortless Postman Collection Import | Simplify API Testing"
 metadesc: "Import Postman collections and environments seamlessly to enhance your API testing. Streamline the process effortlessly with our user-friendly guide."
 noindex: false
-order: 4.16
+order: 4.18
 page_id: "import-postman-collection"
 warning: false
 contextual_links:

--- a/src/pages/docs/test-cases/manage/label-management.md
+++ b/src/pages/docs/test-cases/manage/label-management.md
@@ -3,7 +3,7 @@ title: "Label Management in Testsigma"
 pagetitle: "Label Management in Testsigma"
 metadesc: "The Label Management helps you manage labels linked to test cases, elements, step groups, test suites, and test plans | Label Management in Testsigma Application"
 noindex: false
-order: 4.191
+order: 4.193
 page_id: "Label Management"
 warning: false
 contextual_links:

--- a/src/pages/docs/test-cases/manage/manage-save-points.md
+++ b/src/pages/docs/test-cases/manage/manage-save-points.md
@@ -1,0 +1,59 @@
+---
+title: "Manage Save Points"
+page_title: "Manage Save Points"
+metadesc: "The Save Points feature lets you create, edit, delete, and restore checkpoints manually or during import to revert the project to its exact saved state anytime."
+noindex: false
+order: 4.15
+page_id: "manage-save-points"
+warning: false
+contextual_links:
+- type: section
+  name: "Contents"
+- type: link
+  name: "Interactive Demo"
+  url: "#interactive-demo"
+- type: link
+  name: "Steps to Manage Save Points"
+  url: "#steps-to-manage-save-points"
+---
+
+---
+
+The Save Points feature lets you create checkpoints manually or during import to restore the project to the exact state it was in when the save point was created. You can also create, edit, delete, and restore save points as needed. This article explains how to manage save points in Testsigma. 
+
+---
+
+## **Interactive Demo**
+
+<div>
+  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
+  <div class="sl-embed" style="position:relative;padding-bottom:calc(50.98% + 25px);width:100%;height:0;transform:scale(1)">
+    <iframe loading="lazy" class="sl-demo" src="https://app.storylane.io/demo/olagyeimewap?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
+  </div>
+</div>
+
+---
+
+## **Steps to Manage Save Points**
+
+1. From the left navigation bar, go to **Save Points**.
+
+2. Click **Create Save Point** to save all test cases, elements, test data profiles, and step groups.
+
+3. In the **Create a Save Point?** dialog, enter a name, and click **Create**.
+
+4. Click the **Open this Save Point in new tab** icon to to view the save point in a new tab.
+
+5. Click the **Restore** icon  to revert to the backup version.
+
+6. In the **Restore to this save point?** dialog, enter **RESTORE** and click **I understand, Confirm Restore**.
+
+7. To edit a note of a save point, click the ellipse icon next to it and click **Edit Note**.
+
+8. In the **Edit Note** dialog, update the comment, and click Update.
+
+9. To delete a save point, click the ellipse icon next to it and then click **Delete Save Point**. 
+
+10. In the **Delete this Save Point?** dialog, enter **DELETE** and click **I understand, Delete Save Point**.
+
+---

--- a/src/pages/docs/test-cases/manage/update-test-case-results-in-a-test-plan.md
+++ b/src/pages/docs/test-cases/manage/update-test-case-results-in-a-test-plan.md
@@ -2,7 +2,7 @@
 title: "Update Test Case Result in a Test Plan"
 metadesc: "Change the status of test cases in test plan reports to ignore test case result of known issues | This article discusses how to update the status of a test case in a test plan"
 noindex: false
-order: 4.17
+order: 4.19
 page_id: "Update Test Case Result in a Test Plan"
 warning: false
 contextual_links:

--- a/src/pages/docs/test-cases/manage/view-the-import-summary.md
+++ b/src/pages/docs/test-cases/manage/view-the-import-summary.md
@@ -1,0 +1,53 @@
+---
+title: "View the Import Summary"
+page_title: "View the Import Summary"
+metadesc: "Use the Import Summary feature to check the status and details of your import and verify that the process completed successfully with all items imported."
+noindex: false
+order: 4.16
+page_id: "view-the-import-summary"
+warning: false
+contextual_links:
+- type: section
+  name: "Contents"
+- type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
+  name: "Interactive Demo"
+  url: "#interactive-demo"
+- type: link
+  name: "Steps to View the Import Summary"
+  url: "#steps-to-view-the-import-summary"
+---
+
+---
+
+You can use the Import Summary feature to view the status and details of your import and verify that the process completed as expected. This article explains how to view the import summary. 
+
+---
+
+> ## **Prerequisites**
+> 
+> - Make sure you have imported artefacts from the current project to the destination project.
+---
+
+## **Interactive Demo**
+
+<div>
+  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
+  <div class="sl-embed" style="position:relative;padding-bottom:calc(50.98% + 25px);width:100%;height:0;transform:scale(1)">
+    <iframe loading="lazy" class="sl-demo" src="https://app.storylane.io/demo/lqlipwpocqq0?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
+  </div>
+</div>
+
+---
+
+## **Steps to View the Import Summary**
+
+1. From the left navigation bar, go to **Settings > Imports**.
+
+2. In the **Imports** page, under the **Imports/ Postman Collection** tab, click the status of the import you want to view. 
+
+3. In the **Import Summary** dialog, verify the details, and click  **OK, Got it**. 
+
+---


### PR DESCRIPTION
Added documents for "Import Test Cases" as per the ticket https://testsigma.atlassian.net/browse/IDEA-2366

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/29cb0ef5-228b-45bf-ac58-a2b934564e4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new documentation pages for "Manage Save Points" and "View the Import Summary," including interactive demos and step-by-step instructions.

- **Documentation**
  - Completely revised the documentation for importing test cases, with updated instructions, a new workflow, and an interactive demo.
  - Updated metadata order fields for several documentation pages to improve navigation and organization.
  - Removed outdated export-related content and screenshots from the import documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->