### PR TITLE
Added Additional info to get Env & Version IDs

### DIFF
--- a/src/pages/docs/genai-capabilities/agentic-tests-from-github.md
+++ b/src/pages/docs/genai-capabilities/agentic-tests-from-github.md
@@ -158,10 +158,27 @@ Sprint: <Sprint name>
 
 Testsigma Info Ends
 
+<br>
+
+<div style="background-color: #f8f9fa; padding: 20px; border-radius: 5px; border: 1px solid #dee2e6;">
+  <p style="font-size: 16px; color: #495057;">
+    <b>💡 Additional Info:</b><br><br>
+    <ul style="list-style-type: disc; padding-left: 20px;">
+      <li><b>ApplicationVersionId</b> is the Version ID of the application in Testsigma. To learn how to find the Version ID, see <a href="https://testsigma.com/docs/projects/versions/#getting-version-id">Version ID</a>.</li>
+      <li><b>EnvironmentId</b> is the Environment ID in Testsigma. To learn how to find the Environment ID, see <a href="https://testsigma.com/docs/test-data/types/environment/#getting-environment-id">Environment ID</a>.</li>
+    </ul>
+  </p>
+</div>
+
+<br>
+
+
 **Here’s how the formatted PR will look:**
    ![GiHub Demo PR](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/GitHub_int/GitHub_Demo_PR.png)
 
 [[info | **NOTE**:]]
 | If your PR template includes **Jira**, **Xray**, or **Figma URLs**, ensure these integrations are also added under **Settings > Integrations** in Testsigma.
+
+
 
 ---

--- a/src/pages/docs/projects/versions.md
+++ b/src/pages/docs/projects/versions.md
@@ -22,6 +22,9 @@ contextual_links:
   name: "Delete Application Version"
   url: "#delete-application-version"
 - type: link
+  name: "Getting Version ID"
+  url: "#getting-version-id"
+- type: link
   name: "Interactive Demo"
   url: "#interactive-demo"
 ---
@@ -85,7 +88,15 @@ Due to constantly changing requirements and application features, version contro
 
 4. On the **Delete Version?** dialog, enter **DELETE** and click **I understand, delete this**.
 
+---
 
+## **Getting Version ID**
+
+1. Navigate to **Project Settings > Versions**.
+
+2. In the **EDIT PROJECT** dialog, hover over the version name to view its ID.
+
+3. Click **Copy** to copy the version ID.
 
 ---
 

--- a/src/pages/docs/test-data/types/environment.md
+++ b/src/pages/docs/test-data/types/environment.md
@@ -27,6 +27,10 @@ contextual_links:
 - type: link
   name: "Use Environment Variables to Select Test Data Values"
   url: "#use-environment-variables-to-select-test-data-values"
+- type: link
+  name: "Getting Environment ID"
+  url: "#getting-environment-id"
+
 ---
 
 ---
@@ -139,3 +143,16 @@ Environment variables can filter test data sets by name during data-driven testi
 6. When you run the test case, it will execute using the specified filters. 
 
 
+---
+
+## **Getting Environment ID**
+
+1. Navigate to **Test Data > Environments**. 
+
+2. Click Environment for which you want to get **Environment ID**. 
+
+3. The <ENV_ID> can be found in the URL of the Environment details page.
+   
+   ![Env ID](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/Env_ID.png)
+
+---


### PR DESCRIPTION
Added Additional info to get Env & Version IDs and also added info on getting IDs in Env & Versions documents.
<img width="1716" alt="image" src="https://github.com/user-attachments/assets/3e111fd1-b128-4d6a-8d1a-03c1d0b0aae9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added informational sections explaining how to find and use ApplicationVersionId and EnvironmentId, including step-by-step guides and contextual links.
  - Enhanced documentation with screenshots and clear instructions for locating Version ID and Environment ID within the Testsigma interface.
  - Improved navigation by updating contextual links to these new sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->