### PR TITLE
Added a screenshot to the newly added FAQ doc

### DIFF
--- a/src/pages/docs/FAQs/general/why-am-i-unable-to-download-the-xls-file-from-the-edge-browser.md
+++ b/src/pages/docs/FAQs/general/why-am-i-unable-to-download-the-xls-file-from-the-edge-browser.md
@@ -1,8 +1,8 @@
 ---
-title: "Unable to Download the XLS File from the Edge Browser?"
+title: "Why am I Unable to Download the XLS File from the Edge Browser?"
 metadesc: "Edge may open XLS files in Office Online instead of downloading them. This article explains how to fix it by adjusting a browser setting."
-order: 24
-page_id: "unable-to-download-the-xls-file-from-the-edge-browser-?"
+order: 24.31
+page_id: "why-am-i-unable-to-download-the-xls-file-from-the-edge-browser-?"
 warning: false
 contextual_links:
 - type: section
@@ -26,8 +26,12 @@ To ensure the file downloads instead of opening in the browser, disable the **Op
 
 1. Open **Microsoft Edge** on your device. 
 
-2. Navigate to **edge://settings/downloads**
+2. Navigate to **Settings**.
 
-3. On the **Downloads** page, disable the **Open Office files in the browser** toggle to make Edge download Office files instead of opening them.
+3. In the **Settings** panel, click **Downloads**.
+
+4. On the **Downloads** page, disable the **Open Office files in the browser** toggle to make Edge download Office files instead of opening them.
+
+![Disable the Open Office files in browser](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/faq/Unable_to_download_XLS.png)
 
 ---

--- a/src/pages/docs/FAQs/mobile-apps/how-do-i-enhance-the-execution-speed-for-mobile-native-apps.md.md
+++ b/src/pages/docs/FAQs/mobile-apps/how-do-i-enhance-the-execution-speed-for-mobile-native-apps.md.md
@@ -1,8 +1,8 @@
 ---
-title: "Enhance Execution Speed for Mobile Native Apps"
+title: "How do I Enhance the Execution Speed for Mobile Native Apps?"
 metadesc: "Test execution and recording for React Native or Flutter apps can be slower in Testsigma. | Learn how to speed up actions using desired capabilities."
 order: 24.22
-page_id: "enhance-execution-speed-for-mobile-native-apps"
+page_id: "how-do-i-enhance-the-execution-speed-for-mobile-native-apps-?"
 warning: false
 contextual_links:
 - type: section
@@ -41,7 +41,7 @@ In Testsigma, executing and recording test steps for mobile applications, partic
 
 4. In the **Ad-Hoc Run/ Record test steps** overlay, expand the **Desired Capabilities** field and specify the desired capability. 
 
-   | **Name**     | **Data Type**  | **Value** |
+   | **Name** | **Data Type** | **Value** |
    | ------------- | ------------- | ------------- |
    | appium:waitForIdleTimeout | String | 1000L |
 


### PR DESCRIPTION
Added a screenshot to the newly added FAQ doc - Why am I unable to download the XLS file from the Edge Browser for the ticket https://testsigma.atlassian.net/browse/IDEA-2382 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b1085b3f-8776-484c-b5a9-fa79641bf03d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated FAQ titles to a clearer question format for improved readability.
	- Revised instructions for downloading XLS files in Edge browser, adding clearer steps and a helpful screenshot.
	- Improved formatting in the "Desired Capabilities" table for mobile app performance FAQ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->