### PR TITLE
Removed VPN mentions from the docs

### DIFF
--- a/src/pages/docs/runs/test-locally-hosted-applications.md
+++ b/src/pages/docs/runs/test-locally-hosted-applications.md
@@ -57,14 +57,7 @@ For more information, see [Guide to IP Whitelisting](https://www.linkedin.com/pu
 
 ---
 
-## **2. Secure Tunnel/VPN**
-
-Contact support **support@testsigma.com** to learn more about this. Our team will set up this for you.
-
-
----
-
-## **3. Testsigma Agent**
+## **2. Testsigma Agent**
 
 You can also test locally hosted applications using the Testsigma Agent, which allows test executions on your local machines and mobile devices. To do this, set up the Testsigma Agent utility on your local machine. 
 

--- a/src/pages/docs/troubleshooting/setup/secured-business-application-support.md
+++ b/src/pages/docs/troubleshooting/setup/secured-business-application-support.md
@@ -47,11 +47,6 @@ For more information, refer to:
 
 **5. Addons (To access NLPs)**: Installing Testsigma addons will extend built-in actions with custom actions. These actions can be anything from clicking first, then scrolling, clicking again, scrolling indefinitely till the bottom of the page, and so on. 
 - For more information, refer to [addons](https://testsigma.com/docs/addons/what-is-an-addon/).
-  
-
-**6. VPN Tunneling**: For security reasons, sometimes the recorder cannot access the application while testing Android and iOS apps. In this case, VPN tunneling can be used to establish a secure and encrypted connection over the internet. You can connect with Testsigma support (*support@testsigma.com*) to know more. 
-
-
 
 
 ---


### PR DESCRIPTION
Removed VPN mentions from the docs as per KR's suggestion. 
<img width="1682" height="941" alt="image" src="https://github.com/user-attachments/assets/33de95b8-7379-4838-b539-4c3914c013d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed references to VPN tunneling and secure tunnel setup from relevant documentation sections.
  * Updated instructions for testing locally hosted and secured business applications, including renumbering sections where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->