### PR TITLE
Updated an FAQ

### DIFF
--- a/src/pages/docs/FAQs/general/how-to-test-flutter-apps-using-accessibility-mode.md
+++ b/src/pages/docs/FAQs/general/how-to-test-flutter-apps-using-accessibility-mode.md
@@ -55,4 +55,7 @@ $0.click();
 11. Run your test. It should now successfully interact with the Flutter UI using accessibility-based locators.
     ![Flutter apps 3](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/faq/Flutter_3.png)
     
+[[info | NOTE:]]
+| - Accessibility mode is not supported on iOS devices when using the Safari browser.
+
 ---


### PR DESCRIPTION
Added a note to the "How to Test Flutter Apps Using Accessibility Mode?" doc as per the ticket https://testsigma.atlassian.net/browse/IDEA-2412 
<img width="1722" height="1038" alt="image" src="https://github.com/user-attachments/assets/5b735c11-0d8c-45bc-b8bd-9ab0790d9287" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “How to Test Flutter Apps Using Accessibility Mode?” FAQ with a NOTE stating that Accessibility mode is not supported on iOS devices when using the Safari browser.
  * Clarifies platform/browser limitations to set accurate expectations when testing Flutter apps.
  * Content-only addition; no changes to testing steps or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->