### PR TITLE
Updated the SEO keywords internal linking in Docs

### DIFF
--- a/src/pages/docs/FAQs/web-apps/failure-to-link-text-capture.md
+++ b/src/pages/docs/FAQs/web-apps/failure-to-link-text-capture.md
@@ -30,9 +30,10 @@ In automated testing, test failures often occur when the recorder captures link 
 
 ---
 
-## **Prerequisites**
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [updating an element](https://testsigma.com/docs/elements/web-apps/create-manually/) and [creating a test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
 
-Before you proceed, ensure you know how to create or update an [Element](https://testsigma.com/docs/elements/web-apps/create-manually/) and a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/FAQs/web-apps/viewing-full-testplan-execution-video.md
+++ b/src/pages/docs/FAQs/web-apps/viewing-full-testplan-execution-video.md
@@ -27,7 +27,7 @@ When you enable the **Reset session for every test case** option in **Parallel S
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/),[test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. 
 
 ---
 

--- a/src/pages/docs/accessibility-testing/accessibility-testing.md
+++ b/src/pages/docs/accessibility-testing/accessibility-testing.md
@@ -30,7 +30,7 @@ With Testsigma, you can easily implement accessibility testing to comply with ac
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for  [creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/), [test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. 
 
 ---
 

--- a/src/pages/docs/accessibility-testing/mobile-accessibility-testing.md
+++ b/src/pages/docs/accessibility-testing/mobile-accessibility-testing.md
@@ -32,7 +32,7 @@ With Testsigma, you can implement accessibility testing for Android and iOS appl
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/), [test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/atto/generative-ai/copilot/mobile-recorder.md
+++ b/src/pages/docs/atto/generative-ai/copilot/mobile-recorder.md
@@ -42,7 +42,7 @@ This article discusses test case generation for mobile applications using Testsi
 
 ## **Prerequisites**
 
-Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and have referred to the documentation on [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/atto/generative-ai/copilot/web-recorder.md
+++ b/src/pages/docs/atto/generative-ai/copilot/web-recorder.md
@@ -36,8 +36,7 @@ Testsigma Copilot redefines test automation with the power of generative AI 🤖
 
 > ## **Prerequisites**
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
-
+> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and have referred to the documentation on [creating a test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/best-practices/best-practices.md
+++ b/src/pages/docs/best-practices/best-practices.md
@@ -82,14 +82,14 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 1. Filter, segment, and organise test cases for easy identification to streamline test management processes and quickly locate specific tests.
 2. **Label or map relevant requirements** to test cases to facilitate filtering and improve accessibility. Users can filter and save test cases in separate views based on labelled or mapped requirements.
 3. During test case creation or editing, you can add labels. The label field is available by default in the test case. ![Requirements and Labels](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/req_labels.png)
-4. You can **Save Filters** to quickly access and manage test cases associated with a particular functionality or scenario, such as those related to login. For more information, refer to [save test case filter](https://testsigma.com/docs/test-cases/manage/list-actions/#save-test-case-filter).
+4. You can **Save Filters** to quickly access and manage test cases associated with a particular functionality or scenario, such as those related to login. For more information on how to save test case filter, refer to the documentation on [save test case filter](https://testsigma.com/docs/test-cases/manage/list-actions/#save-test-case-filter).
 
 ---
 
 ## **Customisation and Extensibility**
 
 1. You can use **add-ons to extend Testsigma's repository** of actions and create custom NLPs for specific actions that are not available in the built-in Actions List.
-2. Share your add-ons or leverage existing ones with the test automation community through the Add-ons Community Marketplace. You can use add-ons to provide additional functionality and expand the capabilities of Testsigma. For more information, refer to [create an add-on](https://testsigma.com/docs/addons/create/).
+2. Share your add-ons or leverage existing ones with the test automation community through the Add-ons Community Marketplace. You can use add-ons to provide additional functionality and expand the capabilities of Testsigma. For more information on how to create an add-on, refer to the documentation on [creating an add-on](https://testsigma.com/docs/addons/create/).
 
 [[info | Example:]]
 | You create an add-on for verifying text from two DOM elements.
@@ -98,24 +98,24 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Reusability and Modularity**
 
-1. To avoid duplication and simplify test maintenance, use **Step Groups** as common reusable functions across test cases. Step Groups promote modular test design and easy maintenance by separating reusable components from the test flow. Any changes made to a Step Group will be reflected in all test cases that invoke it. For more information, refer to [step sroups](https://testsigma.com/docs/test-cases/step-types/step-group/).
+1. To avoid duplication and simplify test maintenance, use **Step Groups** as common reusable functions across test cases. Step Groups promote modular test design and easy maintenance by separating reusable components from the test flow. Any changes made to a Step Group will be reflected in all test cases that invoke it. For more information on step groups, refer to the documentation on [step groups](https://testsigma.com/docs/test-cases/step-types/step-group/).
 
 [[info | Example:]]
 | Create a Step Group to reuse login functionality in multiple test cases.
 
-2. Use **REST API Steps** to automate redundant UI actions. Performing these actions through REST API steps will improve test stability and reduce test execution time compared to using the UI. For more information, refer to [Rest API](https://testsigma.com/docs/test-cases/step-types/rest-api/).
+2. Use **REST API Steps** to automate redundant UI actions. Performing these actions through REST API steps will improve test stability and reduce test execution time compared to using the UI. For more information on REST API, refer to the documentation on [Rest API](https://testsigma.com/docs/test-cases/step-types/rest-api/).
 
 ---
 
 ## **Element Management**
 
-1. Create elements with proper naming conventions to enable reuse in multiple test cases. For more information, refer to [create an element](https://testsigma.com/docs/elements/web-apps/create-manually/).
+1. Create elements with proper naming conventions to enable reuse in multiple test cases. For more information on how to create an element, refer to the documentation on [create an element](https://testsigma.com/docs/elements/web-apps/create-manually/).
 
 [[info | Example:]]
 | Use descriptive names such as "UsernameInput" or "LoginButton" to make them easy to identify.
 
-2. You should map appropriate context details when you create elements inside **iFrames** or **Shadow DOM** contexts. Mapping context details will ensure you correctly identify and interact with elements within specific contexts. For more information refer to Shadow DOM Element. For more information, refer to [create a shadow DOM element](https://testsigma.com/docs/elements/web-apps/shadow-dom/#create-element-for-shadow-dom).
-3. You can easily access elements by saving filters and creating views based on screen names. They can check for the presence of elements in Testsigma's repository before recreating them. Element management is facilitated by adding filters. For more information, refer to [save element filters](https://testsigma.com/docs/elements/overview/#save-element-filter).
+2. You should map appropriate context details when you create elements inside **iFrames** or **Shadow DOM** contexts. Mapping context details will ensure you correctly identify and interact with elements within specific contexts. For more information refer to Shadow DOM Element. For more information on how to create a shadow DOM element, refer to the documentation on [create a shadow DOM element](https://testsigma.com/docs/elements/web-apps/shadow-dom/#create-element-for-shadow-dom).
+3. You can easily access elements by saving filters and creating views based on screen names. They can check for the presence of elements in Testsigma's repository before recreating them. Element management is facilitated by adding filters. For more information on how to save element filters, refer to the documentation on[save element filters](https://testsigma.com/docs/elements/overview/#save-element-filter).
 
 [[info | Example:]]
 | Create a view that displays elements related to the ''Login'' screen for quick reference.
@@ -126,15 +126,15 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 |Scope|Description|Usage|
 |---|---|---|
-|**Environment**|<li>The value stays constant during the test execution. The environment variable's values cannot be overwritten.</li><li>Any test case in any test suite can be accessed.</li><li>To create an Environment, navigate to **Test Data** > **Environments** > **Create**. For more information, refer to [environments](https://testsigma.com/docs/test-data/create-environment-data/)</li>|<li>Define base URLs or configuration settings specific to the environment.</li><li>Create test steps using the data type <strong>* url</strong>.</li><li>Example: //button[text()=’*\|url\|’]</li>|
-|**Runtime**|The values are the same throughout a sequential test run; other tests can update them. For more information, refer to [runtime variable](https://testsigma.com/docs/test-data/types/runtime/).|<li>During test execution, store session-specific data or dynamic values.</li><li>Create test steps using the data type <strong>$ divText</strong>.</li><li>Example: //button[text()=’$\|divText\|’] </li>|
-|**Test Data Profile**|<li>You can link specific test cases. You can update the values in test data profiles from other test cases.</li><li>To create a Test Data Profile, navigate to **Test Data** > **Test Data Profile** > **Create**. For more information, refer to [test data profile](https://testsigma.com/docs/test-data/create-data-profiles/)</li>|<li>Use data-driven testing and maintain test data sets.</li><li>Create test steps using the data type **@ username**.</li><li>Example: //button[text()=’@\|username\|’]</li>|
+|**Environment**|<li>The value stays constant during the test execution. The environment variable's values cannot be overwritten.</li><li>Any test case in any test suite can be accessed.</li><li>To create an Environment, navigate to **Test Data** > **Environments** > **Create**. For more information on environments, refer to the documentation on [environments](https://testsigma.com/docs/test-data/create-environment-data/)</li>|<li>Define base URLs or configuration settings specific to the environment.</li><li>Create test steps using the data type <strong>* url</strong>.</li><li>Example: //button[text()=’*\|url\|’]</li>|
+|**Runtime**|The values are the same throughout a sequential test run; other tests can update them. For more information on runtime varibale, refer to the documentation on [runtime variable](https://testsigma.com/docs/test-data/types/runtime/).|<li>During test execution, store session-specific data or dynamic values.</li><li>Create test steps using the data type <strong>$ divText</strong>.</li><li>Example: //button[text()=’$\|divText\|’] </li>|
+|**Test Data Profile**|<li>You can link specific test cases. You can update the values in test data profiles from other test cases.</li><li>To create a Test Data Profile, navigate to **Test Data** > **Test Data Profile** > **Create**. For more information on test data profile, refer to the documentation on [test data profile](https://testsigma.com/docs/test-data/create-data-profiles/)</li>|<li>Use data-driven testing and maintain test data sets.</li><li>Create test steps using the data type **@ username**.</li><li>Example: //button[text()=’@\|username\|’]</li>|
 
 ---
 
 ## **Data-Driven Testing**
 
-1. Enable the data-driven toggle in test cases and use Test Data Profiles to perform the same action with different test data sets for data-driven testing. For more information, refer to [data driven testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
+1. Enable the data-driven toggle in test cases and use Test Data Profiles to perform the same action with different test data sets for data-driven testing. For more information on data driven testing, refer to the documentation on [data driven testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
 2. Test Data Profiles use key-value pair format to store project configuration data, database connection details, and project settings for easy access and reuse of test data.
 
 [[info | Example:]]
@@ -164,13 +164,13 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Configuration for Test Execution**
 
-1. Upload attachments for test steps in **Test Data** > **Uploads** and follow the maximum file size limit of **1024 MB**. The system always considers the latest version of the uploaded file. For more information, refer to [uploads](https://testsigma.com/docs/uploads/upload-files/).
-2. Configure **Desired Capabilities** for cross-browser testing with specific browser configurations. You can configure Desired Capabilities for ad-hoc runs and test plans. For more information, refer to [desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/).
+1. Upload attachments for test steps in **Test Data** > **Uploads** and follow the maximum file size limit of **1024 MB**. The system always considers the latest version of the uploaded file. For more information on uploads, refer to the documentation on [uploads](https://testsigma.com/docs/uploads/upload-files/).
+2. Configure **Desired Capabilities** for cross-browser testing with specific browser configurations. You can configure Desired Capabilities for ad-hoc runs and test plans. For more information on desired capabilities, refer to the documentation on [desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/).
 
 [[info | Example:]]
 | Specify the desired capabilities of the targeted testing, such as browser version or device type.
 
-3. Ensure you put test cases in the Ready state before adding them to a Test Suite. Organise relevant tests into test suites for better organisation and execution. For more information, refer to [test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+3. Ensure you put test cases in the Ready state before adding them to a Test Suite. Organise relevant tests into test suites for better organisation and execution. For more information on test suites, refer to the documentation on [test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
 
 [[info | Example:]]
 | Create a "Login Suite" and add all relevant login-related test cases for efficient execution.
@@ -179,13 +179,13 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Execution and Test Plan Run**
 
-1. Run test case and test plan in **Headless** mode to reduce execution time and eliminate element loading time. For more information, refer to [headless browser testing](https://testsigma.com/docs/test-management/test-plans/headless-testing/).
+1. Run test case and test plan in **Headless** mode to reduce execution time and eliminate element loading time. For more information on headless browser testing, refer to the documentation on [headless browser testing](https://testsigma.com/docs/test-management/test-plans/headless-testing/).
 
 [[info | Example:]]
 | To achieve faster test execution, execute the test plan without a visible browser.
 
-2. Use the **Partial Run** option in the Test Plan to exclude consistently failing test suites from runs; you can exclude or disable tests for execution from the Test Machines & Suites Selection in the Test Plan. For more information, refer to [partial run](https://testsigma.com/docs/runs/test-plan-executions/#partial-test-runs).
-3. Use the **Schedule** feature to run the test plan automatically without manual intervention. For more information, refer to [schedule a test plan](https://testsigma.com/docs/test-management/test-plans/schedule-plans/).
+2. Use the **Partial Run** option in the Test Plan to exclude consistently failing test suites from runs; you can exclude or disable tests for execution from the Test Machines & Suites Selection in the Test Plan. For more information on partial run, refer to the documentation on [partial run](https://testsigma.com/docs/runs/test-plan-executions/#partial-test-runs).
+3. Use the **Schedule** feature to run the test plan automatically without manual intervention. For more information on how to schedule a test plan, refer to the documentation on [schedule a test plan](https://testsigma.com/docs/test-management/test-plans/schedule-plans/).
 
 [[info | Example:]]
 | Schedule unattended testing during non-business hours by executing the test plan.
@@ -194,7 +194,7 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Testsigma Recorder Extension**
 
-1. Use the Testsigma Recorder Extension to record user interactions on web applications. Customise and modify the recorded test steps to align with the desired test case behaviour. For more information, refer to [recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
+1. Use the Testsigma Recorder Extension to record user interactions on web applications. Customise and modify the recorded test steps to align with the desired test case behaviour. For more information on how to record test steps, refer to the documentation on [recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
 2. Use the **Automatic Element Identification** feature of the recorder extension to easily capture elements and apply validations and verifications during recording to ensure that test steps include necessary assertions.
 
 ---

--- a/src/pages/docs/collaboration/elements-review-management.md
+++ b/src/pages/docs/collaboration/elements-review-management.md
@@ -36,8 +36,7 @@ There are two ways to review an element:
 > ## **Prerequisites**
 >
 > 
-> Before using **Test Case Review Management**, you must understand specific concepts such as creating [Elements](https://testsigma.com/docs/elements/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and managing [Users and Roles](https://testsigma.com/docs/collaboration/users-roles/). Also, make sure the option **Element Review Management** is enabled under **Settings > Preferences**.
-
+> Before you begin, ensure that you have referred to the documentation for [creating elements](https://testsigma.com/docs/elements/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and managing [users and roles](https://testsigma.com/docs/collaboration/users-roles/). Also, make sure the option **Element Review Management** is enabled under **Settings > Preferences**.
 
 ---
 

--- a/src/pages/docs/collaboration/test-cases-review-management.md
+++ b/src/pages/docs/collaboration/test-cases-review-management.md
@@ -40,7 +40,8 @@ This documentation will guide you through enabling and using Test Case Review Ma
 > ## **Prerequisites**
 >
 > 
-> Before using Test Case Review Management, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and managing [Users and Roles](https://testsigma.com/docs/collaboration/users-roles/).
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and [managing users and roles](https://testsigma.com/docs/collaboration/users-roles/) in Test Case Review Management.
+
 
 ---
 

--- a/src/pages/docs/continuous-integration/copado-integration.md
+++ b/src/pages/docs/continuous-integration/copado-integration.md
@@ -24,7 +24,7 @@ Testsigma Copado integration allows you to trigger test plan execution every tim
 
 > ## **Prerequisites**
 > 
-> Before you begin, ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) for Salesforce, [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) for Salesforce, and [Generating API Keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key) in Testsigma.
+> Before you begin, ensure that you have referred to the documentation for [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/)  for Salesforce, [test plans](https://testsigma.com/docs/test-management/test-plans/overview/) for Salesforce, and [generating API keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key) in Testsigma.
 
 ---
 

--- a/src/pages/docs/continuous-integration/gearset.md
+++ b/src/pages/docs/continuous-integration/gearset.md
@@ -24,7 +24,7 @@ Testsigma Gearset integration allows you to trigger test plan execution every ti
 
 > ## **Prerequisites**
 > 
-> Before you begin, ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) for Salesforce, [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) for Salesforce, and [Generating API Keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key) in Testsigma.
+> Before you begin, ensure that you have referred to the documentation for  [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) for Salesforce, [creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/) for Salesforce, and [generating API keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key) in Testsigma.
 
 ---
 

--- a/src/pages/docs/desired-capabilities/basic-authentication-safari.md
+++ b/src/pages/docs/desired-capabilities/basic-authentication-safari.md
@@ -29,7 +29,7 @@ Safari restricts automated Basic Authentication login by blocking credentials in
 
 > ## **Prerequisites**
 > 
-> Before you begin, ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/), and [Desired Capabilities](https://testsigma.com/docs/desired-capabilities/overview/) in Testsigma.
+> Before you begin, ensure that you have referred to the documentation for [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/), and [desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/desired-capabilities/enable-browser-console-logs.md
+++ b/src/pages/docs/desired-capabilities/enable-browser-console-logs.md
@@ -30,9 +30,9 @@ Browser Console Debug logs can help you more effectively identify and troublesho
 
 ---
 
-## **Prerequisites**
-
-Before you begin, grasp the basics of creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) and performing [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/) and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test plans](https://testsigma.com/docs/test-management/test-plans/overview/), [performing Ad-hoc runs](https://testsigma.com/docs/runs/adhoc-runs/) and  [test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. 
 
 ---
 

--- a/src/pages/docs/desired-capabilities/incognito-mode.md
+++ b/src/pages/docs/desired-capabilities/incognito-mode.md
@@ -29,9 +29,10 @@ Desired Capabilities allow you to customise the test environment by adding brows
 
 ---
 
-## **Prerequisites**
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test plans](https://testsigma.com/docs/test-management/test-plans/overview/), [Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/) and [test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. 
 
-Before starting testing in Incognito/Private Mode, you must understand specific concepts, such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/), managing [Ad-hoc runs](https://testsigma.com/docs/runs/adhoc-runs/) and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/desired-capabilities/network-logs.md
+++ b/src/pages/docs/desired-capabilities/network-logs.md
@@ -32,9 +32,10 @@ This documentation will guide you on how to enable the network log in Test Case 
 
 ---
 
-## **Prerequisites**
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test plans](https://testsigma.com/docs/test-management/test-plans/overview/), [Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/), and [test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
 
-Before starting, understand the concepts of [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/), [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/), and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. Familiarising yourself with these concepts will make working with the Network Log feature easier.
 
 [[info | Note:]]
 | By default, Network Log is enabled for Web and Mobile Web applications, but for Android and iOS applications, you need to enable it manually.

--- a/src/pages/docs/elements/dynamic-elements/with-runtime-test-data.md
+++ b/src/pages/docs/elements/dynamic-elements/with-runtime-test-data.md
@@ -28,9 +28,9 @@ Dynamic locators are essential in handling web elements that may undergo attribu
 
 ---
 
-## **Prerequisites**
-
-Before implementing dynamic locators using Runtime in Testsigma, ensure you have a solid understanding of key concepts such as creating a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), managing [Runtime Test Data](https://testsigma.com/docs/test-data/types/runtime/) and [Elements](https://testsigma.com/docs/elements/web-apps/capture-single-element/), handling [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and effectively utilising different [Test Data Types](https://testsigma.com/docs/test-data/types/overview/).
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), managing [runtime test data](https://testsigma.com/docs/test-data/types/runtime/) and [elements](https://testsigma.com/docs/elements/web-apps/capture-single-element/), handling [test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and utilising different [test data types](https://testsigma.com/docs/test-data/types/overview/).
 
 ---
 

--- a/src/pages/docs/elements/web-apps/shadow-dom.md
+++ b/src/pages/docs/elements/web-apps/shadow-dom.md
@@ -32,7 +32,7 @@ To perform reliable tests, you need to find these elements. This guide will expl
 ---
 > ## **Prerequisites**
 >
-> Before you begin, ensure that you understand specific concepts such as creating [projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [elements](https://testsigma.com/docs/elements/overview/), and [recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [elements](https://testsigma.com/docs/elements/overview/), and for [recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
 
 ---
 

--- a/src/pages/docs/genai-capabilities/copilot.md
+++ b/src/pages/docs/genai-capabilities/copilot.md
@@ -36,7 +36,7 @@ Testsigma Copilot redefines test automation with the power of generative AI 🤖
 
 > ## **Prerequisites**
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and and referred to the documentation for creating test cases [documentation for creating test sases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma. 
 
 
 ---

--- a/src/pages/docs/genai-capabilities/generate-tdp.md
+++ b/src/pages/docs/genai-capabilities/generate-tdp.md
@@ -25,8 +25,7 @@ With Testsigma Copilot, you can quickly generate a Test Data Profile. This elimi
 
 > ## **Prerequisites**
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Data Profiles](https://testsigma.com/docs/test-data/create-data-profiles/) in Testsigma.
-
+> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and have referred to the documentation for [understanding test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [test data profiles](https://testsigma.com/docs/test-data/create-data-profiles/) in Testsigma.
 
 ---
 
@@ -40,7 +39,7 @@ With Testsigma Copilot, you can quickly generate a Test Data Profile. This elimi
 
 3. In the **Test Case Details** page, click **Record** to open the **Testsigma Test Recorder** in a new window.
 
-4. Create test steps by performing actions or use **Copilot** to generate steps automatically. *For more information, see [Creating Test Cases Using Copilot](https://testsigma.com/docs/test-cases/create-test-steps/overview/#ai-test-automation-with-testsigma-copilot-).*
+4. Create test steps by performing actions or use **Copilot** to generate steps automatically. *For more information on creating test cases uisng Copilot, refer to the documentation on [creating test cases using Copilot](https://testsigma.com/docs/test-cases/create-test-steps/overview/#ai-test-automation-with-testsigma-copilot-).*
 5. When you're done, click **Stop** to end the session. You will be redirected to the **Test Case Details** page.
 
 6. A confirmation dialog will appear.

--- a/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
@@ -44,7 +44,7 @@ With Testsigma, you can effortlessly generate test cases directly from Figma des
 
 > ## **Prerequisites**
 >
-> Before you begin, enable AI features from **Settings > Preferences > Generative AI features** and ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
+> Before you begin, enable AI features from **Settings > Preferences > Generative AI features** and referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) in Testsigma.
 
 
 ---

--- a/src/pages/docs/genai-capabilities/generate-tests-from-requirements.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-requirements.md
@@ -31,7 +31,7 @@ With Testsigma, you can create test cases directly from Jira stories and epics b
 
 > ## **Prerequisites**
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features**, integrate [Jira with Testsigma](https://testsigma.com/docs/integrations/bug-reporting/jira/) and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features**, refer to the documentation for [integrating Jira with Testsigma](https://testsigma.com/docs/integrations/bug-reporting/jira/) , and [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/genai-capabilities/generate-tests-from-user-actions.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-user-actions.md
@@ -27,7 +27,7 @@ This article discusses generating end to end automated test cases based on user 
 
 > ## **Prerequisites**
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and have referred to the documentation for [understanding test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/genai-capabilities/mobile-copilot.md
+++ b/src/pages/docs/genai-capabilities/mobile-copilot.md
@@ -43,9 +43,9 @@ This article discusses test case generation for mobile applications using Testsi
 
 ---
 
-## **Prerequisites**
-
-Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> ## **Prerequisites**
+> 
+> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and refer to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/getting-started/testsigma-sample-apps.md
+++ b/src/pages/docs/getting-started/testsigma-sample-apps.md
@@ -25,7 +25,7 @@ This article provides a few sample applications for users to practice testing in
 
     - https://mobile-simply-travel.testsigma.com/
 
-*For more information on how to create test cases, refer to [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
+*For more information on how to create test cases, refer to the documentation on [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
 
 
 2. Use the following apps for practicing mobile app testing.
@@ -36,7 +36,7 @@ This article provides a few sample applications for users to practice testing in
     - [SMS Forwarder Application](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/smsforward.apk)
 
 
-*For more information on uploading mobile apps for testing, refer to [upload android and iOS apps](https://testsigma.com/docs/uploads/upload-apps/).*
+*For more information on uploading mobile apps for testing, refer to the documentation on [upload android and iOS apps](https://testsigma.com/docs/uploads/upload-apps/).*
 
 3. Use the following link for practicing API testing:
 

--- a/src/pages/docs/integrations/test-management/qtest.md
+++ b/src/pages/docs/integrations/test-management/qtest.md
@@ -38,7 +38,7 @@ qTest is a manual test management tool. With qTest integration in Testsigma, you
 > ## **Prerequisites**
 >
 > 
-> Before you begin, ensure you have a valid **Host URL** and **Bearer Token** from qTest. Also, make sure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma.
+> Before you begin, ensure you have a valid **Host URL** and **Bearer Token** from qTest and have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [test plans](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma. 
 
 ---
 

--- a/src/pages/docs/integrations/test-management/testrail.md
+++ b/src/pages/docs/integrations/test-management/testrail.md
@@ -38,7 +38,7 @@ You can integrate Testsigma with TestRail to streamline test management and trac
 
 > ## **Prerequisites**
 > 
-> Before you begin, ensure you have a valid **Host URL**, **Username**, and **Password** from TestRail. Also, make sure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma.
+> Before you begin, ensure that you have a valid **Host URL**, **Username**, and **Password** from TestRail. Also, refer to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [test plans](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma.
 
 
 ---

--- a/src/pages/docs/live-editor/editing-test-case.md
+++ b/src/pages/docs/live-editor/editing-test-case.md
@@ -27,8 +27,7 @@ In Testsigma, Live Editor gives you complete control over test cases while execu
 
 > ## **Prerequisites**
 > 
-> Before you begin, ensure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and install **Testsigma Terminal** application.
-
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and installing the Testsigma Terminal application.
 
 ---
 

--- a/src/pages/docs/reports/runs/drill-down-reports.md
+++ b/src/pages/docs/reports/runs/drill-down-reports.md
@@ -43,7 +43,8 @@ In Testsigma, you can view and download reports from the Run Results page. This 
 
 > ## **Prerequisites**
 >
-> Before you begin, make sure you have created and executed a [test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to the documentation for [creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+
 
 ---
 

--- a/src/pages/docs/reports/runs/filter-custom-reports.md
+++ b/src/pages/docs/reports/runs/filter-custom-reports.md
@@ -26,8 +26,7 @@ Quickly view the run results of a test plan by applying filters | Learn how to a
 
 > ## **Prerequisites**
 >
-> Before you begin, make sure you have created and executed a [test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
-
+> Before you begin, ensure that you have referred to the documentation for [creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/runs/adhoc-runs.md
+++ b/src/pages/docs/runs/adhoc-runs.md
@@ -43,9 +43,9 @@ This documentation will guide you through setting up Test Labs and Test Machines
 
 ---
 
-## **Prerequisites:**
-
-Before using the Ad-hoc Run, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/) and [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), understanding [Test Labs](https://testsigma.com/docs/test-management/test-plans/supported-test-lab-types/), setting up [Local Devices with Testsigma Agent](https://testsigma.com/docs/agent/overview/), [Environments](https://testsigma.com/docs/test-data/types/environment/#use-environment-in-ad-hoc-run-page), [Headless Tests](https://testsigma.com/docs/test-management/test-plans/headless-testing/#enabling-headless-browser-testing-in-test-case), and [Desired Capabilities](https://testsigma.com/docs/desired-capabilities/overview/) for all applications. You should also be familiar with [Uploads](https://testsigma.com/docs/uploads/upload-apps/), [Camera Image Injection](https://testsigma.com/docs/test-cases/image-injection/) and [Network Logs](https://testsigma.com/docs/desired-capabilities/network-logs/#enable-network-logs-in-test-case) for Android and iOS applications.
+> ## **Prerequisites:**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/),  [understanding test labs](https://testsigma.com/docs/test-management/test-plans/supported-test-lab-types/), setting up [local devices with Testsigma Agent](https://testsigma.com/docs/agent/overview/), [environments](https://testsigma.com/docs/test-data/types/environment/#use-environment-in-ad-hoc-run-page), [headless tests](https://testsigma.com/docs/test-management/test-plans/headless-testing/#enabling-headless-browser-testing-in-test-case), [desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/) for all applications, [uploads](https://testsigma.com/docs/uploads/upload-apps/), [camera image injection](https://testsigma.com/docs/test-cases/image-injection/), and [network logs](https://testsigma.com/docs/desired-capabilities/network-logs/#enable-network-logs-in-test-case) for Android and iOS applications. 
 
 ---
 

--- a/src/pages/docs/test-cases/create-test-steps/actions-and-options-manual/step-options.md
+++ b/src/pages/docs/test-cases/create-test-steps/actions-and-options-manual/step-options.md
@@ -50,9 +50,7 @@ In Testsigma, you can customize test steps within a test case using test step op
 
 > ## **Prerequisites**
 >   
-> - You should know how to [manage a Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
->
-> - You should know how to [manage Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
+> Before you begin, ensure that you have referred to the documentation for [managing a test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
 
 ---
 

--- a/src/pages/docs/test-cases/image-injection.md
+++ b/src/pages/docs/test-cases/image-injection.md
@@ -26,9 +26,9 @@ Testsigma enables you to enhance your testing process by inserting images into y
 
 ---
 
-## **Prerequisites**
-
-Before using Image Injection, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), [Test Data Types](https://testsigma.com/docs/test-data/types/overview/), [Uploading Applications](https://testsigma.com/docs/uploads/upload-apps/), [Uploading Files](https://testsigma.com/docs/uploads/upload-files/), recording steps for [Android](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-recorder/step-settings/#reordering-test-steps) and [iOS](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-options/#reorder-test-step), and performing Ad-hoc runs in [Android](https://testsigma.com/docs/runs/adhoc-runs/#android-application) and [iOS](https://testsigma.com/docs/runs/adhoc-runs/#ios-application).
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), [test data types](https://testsigma.com/docs/test-data/types/overview/), [uploading applications](https://testsigma.com/docs/uploads/upload-apps/) and [files](https://testsigma.com/docs/uploads/upload-files/), recording steps for [android](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-recorder/step-settings/#reordering-test-steps)  and[iOS](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-options/#reorder-test-step), and performing Ad-hoc Runs in [android](https://testsigma.com/docs/runs/adhoc-runs/#android-application) and [iOS](https://testsigma.com/docs/runs/adhoc-runs/#ios-application).
 
 [[info | Note:]]
 | Ensure that you upload image files in **PNG** format for Image Injection, which is exclusively available for **Android** and **iOS** apps, and allow a few seconds for the scanner to complete the image scan.

--- a/src/pages/docs/test-cases/manage/label-management.md
+++ b/src/pages/docs/test-cases/manage/label-management.md
@@ -33,7 +33,7 @@ The Label Management feature in Testsigma helps you manage labels linked to test
 
 > ## **Prerequisites**
 > 
-> Before you begin, ensure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Elements](https://testsigma.com/docs/elements/overview/), [Step Groups](https://testsigma.com/docs/test-cases/step-types/step-group/), [Test Suites](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [elements](https://testsigma.com/docs/elements/overview/), [step groups](https://testsigma.com/docs/test-cases/step-types/step-group/),[test suites](https://testsigma.com/docs/test-management/test-suites/overview/), and [test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/test-cases/step-types/block.md
+++ b/src/pages/docs/test-cases/step-types/block.md
@@ -40,7 +40,7 @@ In Testsigma, a step block can be created using two different methods:
 
 > ### **Prerequisites**
 > 
-> Before using the Step Block, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), and understanding [Test Step Types](https://testsigma.com/docs/test-cases/step-types/overview/) and [Bulk Actions](https://testsigma.com/docs/test-cases/create-steps-nl/bulk-actions/).
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), [test step types](https://testsigma.com/docs/test-cases/step-types/overview/), and [Bulk Actions](https://testsigma.com/docs/test-cases/create-steps-nl/bulk-actions/) in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-cases/step-types/natural-language.md
+++ b/src/pages/docs/test-cases/step-types/natural-language.md
@@ -26,9 +26,9 @@ In Testsigma, you can quickly create test steps using natural language or simple
 
 ---
 
-## **Prerequisites**
-- You should know how to create [Test Data](https://testsigma.com/docs/test-data/types/overview/) and [Elements](https://testsigma.com/docs/elements/web-apps/overview/). 
-- You should know how to [create a Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/). 
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test data](https://testsigma.com/docs/test-data/types/overview/), [elements](https://testsigma.com/docs/elements/web-apps/overview/), and [test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/). 
 
 ---
 

--- a/src/pages/docs/test-cases/step-types/overview.md
+++ b/src/pages/docs/test-cases/step-types/overview.md
@@ -50,7 +50,7 @@ An automated test case is a step-by-step logic that simulates user interactions 
 
 ![Side Panel](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/tstypesidepanel.png)
 
-You can choose the type of test step you want to add to your test case from the panel. Read more about the different test steps and how to create them in the links below:
+You can choose the type of test step you want to add to your test case from the panel. For more information, refer to the documentation on: 
 
 - [Natural Language](https://testsigma.com/docs/test-cases/step-types/natural-language/)
 

--- a/src/pages/docs/test-cases/step-types/rest-api.md
+++ b/src/pages/docs/test-cases/step-types/rest-api.md
@@ -26,7 +26,7 @@ Using Rest API Testing in Testsigma, you can validate the behaviour of RESTful A
 ---
 ### **Prerequisites**
 
-Before using the Rest API in a test step, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), using [Test Step Types](https://testsigma.com/docs/test-cases/step-types/overview/) and understanding [RESTful API Testing](https://testsigma.com/docs/test-cases/create-steps-restapi/restful-api-overview/).
+Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/),  [test step types](https://testsigma.com/docs/test-cases/step-types/overview/), and [RESTful API testing](https://testsigma.com/docs/test-cases/create-steps-restapi/restful-api-overview/).
 
 ---
 
@@ -39,7 +39,7 @@ Before using the Rest API in a test step, you must understand specific concepts 
 Here is a quick GIF demonstrating the above workflow: ![Add Rest API in Test Step](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/addrestapi_teststep.gif)
 
 [[info | NOTE:]]
-| Refer to how to [Create a Project](https://testsigma.com/docs/projects/overview/#creating-a-project) for Rest API to create a separate **Rest API Application** in the project for conducting RESTful API Testing.
+| For more information on how to create a project, refer to the documentation on [creating a project](https://testsigma.com/docs/projects/overview/#creating-a-project) to set up a separate REST API Application within the project for performing RESTful API testing.
 
 ---
 
@@ -73,7 +73,7 @@ Follow the steps below on the Rest API screen, which will appear, to configure y
 Here is a quick GIF demonstrating the above workflow: ![Configure Rest API test step](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/config_restapitst2.gif)
 
 [[info | NOTE:]]
-| For more information on RESTful API testing in a test case, refer to [RESTful API Testing](https://testsigma.com/docs/test-cases/create-steps-restapi/restful-api-overview/).
+| For more information on RESTful API testing in a test case, refer to the documentation on [RESTful API testing](https://testsigma.com/docs/test-cases/create-steps-restapi/restful-api-overview/).
 
 ---
 

--- a/src/pages/docs/test-data/create-data-profiles.md
+++ b/src/pages/docs/test-data/create-data-profiles.md
@@ -40,7 +40,7 @@ Test data profiles can significantly enhance the efficiency of your testing proc
 
 > ## **Prerequisites**
 >
-> Before you begin, ensure you're familiar with concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
+> Before you begin, ensure that you have referred to the documentation for [understanding test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/address-function-type.md
+++ b/src/pages/docs/test-data/data-generators/address-function-type.md
@@ -83,9 +83,9 @@ Address functions generate various components of address data, such as street na
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/change-data-type-function-type.md
+++ b/src/pages/docs/test-data/data-generators/change-data-type-function-type.md
@@ -26,9 +26,9 @@ Change Data Type function allows you to transform an input value into a specifie
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/company-function-type.md
+++ b/src/pages/docs/test-data/data-generators/company-function-type.md
@@ -50,9 +50,9 @@ Company Functions are data generator tools that create realistic company-related
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/datefunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/datefunctions-function-type.md
@@ -56,9 +56,9 @@ DateFunctions enable you to generate and manipulate dates dynamically in various
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/default-list.md
+++ b/src/pages/docs/test-data/data-generators/default-list.md
@@ -57,7 +57,7 @@ contextual_links:
 
 ---
 
-Testsigma offers a variety of predefined data types, including text, number, date, email, phone number, and others. You can use these data types to create test data for various field types. Refer to [test data generator usage in test steps](https://testsigma.com/docs/test-data/types/data-generator/) to learn how to use the default test data generators in your test steps.
+Testsigma offers a variety of predefined data types, including text, number, date, email, phone number, and others. You can use these data types to create test data for various field types. For more information on test data generator usage in test steps, refer to the documentation on [test data generator usage in test steps](https://testsigma.com/docs/test-data/types/data-generator/). 
 
 The following list categorises the available default test data generators.
 

--- a/src/pages/docs/test-data/data-generators/domainfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/domainfunctions-function-type.md
@@ -26,9 +26,9 @@ Domain Functions design email addresses with specific domains. They create email
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/emailfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/emailfunctions-function-type.md
@@ -38,9 +38,9 @@ The EmailFunctions function type enables users to generate various types of emai
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case)s and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/file-function-type.md
+++ b/src/pages/docs/test-data/data-generators/file-function-type.md
@@ -35,9 +35,9 @@ You can generate and manage various file-related data. This functionality is use
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/friends-function-type.md
+++ b/src/pages/docs/test-data/data-generators/friends-function-type.md
@@ -29,9 +29,9 @@ TestDataFromProfile functions enable users to retrieve specific test data from d
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for creating [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/idnumber-function-type.md
+++ b/src/pages/docs/test-data/data-generators/idnumber-function-type.md
@@ -38,9 +38,9 @@ You can generate and manage various file-related data. This functionality is use
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for creating [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/internet-function-type.md
+++ b/src/pages/docs/test-data/data-generators/internet-function-type.md
@@ -56,9 +56,9 @@ The Internet Function Type and Function for Data Generators offer various functi
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for creating [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/mailboxaliasfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/mailboxaliasfunctions-function-type.md
@@ -50,9 +50,9 @@ MailBoxAlias Functions enable dynamic interaction with email data in testing and
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [MailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps, and [using MailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/mailboxfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/mailboxfunctions-function-type.md
@@ -56,9 +56,9 @@ MailBoxFunctions are specialized tools that facilitate efficient email managemen
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [MailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata 
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps, and [using mailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/name-function-type.md
+++ b/src/pages/docs/test-data/data-generators/name-function-type.md
@@ -50,9 +50,9 @@ The Name Function within data generators offers a variety of functions designed 
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before utilising the different data generator functions, it's essential to understand basic concepts such as [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case), [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/namefunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/namefunctions-function-type.md
@@ -26,9 +26,9 @@ NameFunctions Function Type in data generators helps you create usernames. It pr
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for creating [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/number-function-type.md
+++ b/src/pages/docs/test-data/data-generators/number-function-type.md
@@ -47,10 +47,9 @@ The Number Function Type allows you to generate various types of random numbers.
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
-
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 ---
 
 ## **Selecting Number as a Function Type for Data Generator**

--- a/src/pages/docs/test-data/data-generators/numberfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/numberfunctions-function-type.md
@@ -26,9 +26,9 @@ NumberFunctions function type allows you to perform mathematical operations on n
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/phone-function-type.md
+++ b/src/pages/docs/test-data/data-generators/phone-function-type.md
@@ -29,9 +29,9 @@ Phone Number Function Type allows you to generate random, realistic phone number
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/phonenumberfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/phonenumberfunctions-function-type.md
@@ -26,9 +26,9 @@ Phone Number Function Type in data generators allows you to generate valid phone
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and for[adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/random-string-function-type.md
+++ b/src/pages/docs/test-data/data-generators/random-string-function-type.md
@@ -26,9 +26,9 @@ NameFunctions Function Type in data generators helps you create usernames. It pr
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+>
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case), [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/random-text-function-type.md
+++ b/src/pages/docs/test-data/data-generators/random-text-function-type.md
@@ -26,9 +26,9 @@ RandomText Function Type allows you to generate random text strings of specified
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for creating [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/stringfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/stringfunctions-function-type.md
@@ -29,9 +29,9 @@ StringFunctions allow you to manipulate and transform text strings effortlessly.
 
 ---
 
-## **Prerequisites**
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [Parameters](https://testsigma.com/docs/test-data/types/parameter/), [Runtime](https://testsigma.com/docs/test-data/types/runtime/) and [Environments](https://testsigma.com/docs/test-data/types/environment/).
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps, [parameters](https://testsigma.com/docs/test-data/types/parameter/), [runtime](https://testsigma.com/docs/test-data/types/runtime/), and [environments](https://testsigma.com/docs/test-data/types/environment/).
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/testdatafromprofile-function-type.md
+++ b/src/pages/docs/test-data/data-generators/testdatafromprofile-function-type.md
@@ -31,7 +31,7 @@ TestDataFromProfile functions enable users to retrieve specific test data from d
 
 ## **Prerequisites**
 
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [Test Data Profile](https://testsigma.com/docs/test-data/create-data-profiles/).
+Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case), [creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/), [adding data generators in test steps](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps), and [Test Data Profiles](https://testsigma.com/docs/test-data/create-data-profiles/).
 
 ---
 

--- a/src/pages/docs/test-data/types/data-generator.md
+++ b/src/pages/docs/test-data/types/data-generator.md
@@ -10,6 +10,9 @@ contextual_links:
 - type: section
   name: "Contents"
 - type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
   name: "Add Data Generators in Test Steps"
   url: "#add-data-generators-in-test-steps"
 ---
@@ -20,9 +23,10 @@ Testsigma allows you to automatically generate test data during test execution t
 
 ---
 
-### **Prerequisites**
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for[creating projects](https://testsigma.com/docs/projects/overview/),  [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/),  [Creating test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), and [using test data types](https://testsigma.com/docs/test-data/types/overview/), as well as for [using default test data generators](https://testsigma.com/docs/test-data/data-generators/default-list/) and [creating custom test data generators](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/) with Java. 
 
-Before using the Data Generators, you must understand specific concepts such as [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Create Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/) and [Test Data Types](https://testsigma.com/docs/test-data/types/overview/). Testsigma offers a collection of built-in test data generators in [Default Test Data Generators](https://testsigma.com/docs/test-data/data-generators/default-list/). Furthermore, you can [create custom test data generators](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/) using Java.
 
 ---
 

--- a/src/pages/docs/test-data/types/environment.md
+++ b/src/pages/docs/test-data/types/environment.md
@@ -41,10 +41,7 @@ In Testsigma, you can handle and use specific sets of test data linked to differ
 
 > ## **Prerequisites**
 > 
-> - You should know how to create a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/). 
-> - You should know how to create an [Environment](https://testsigma.com/docs/test-data/create-environment-data/).
-> - You should know how to create a [Test Plan](https://testsigma.com/docs/runs/test-plan-executions/#steps-to-create-and-execute-test-plan) and how to use them with [Test Data Types](https://testsigma.com/docs/test-data/types/overview/).
-> - You should know how to perform [Ad-Hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/#steps-to-perform-ad-hoc-runs-for-a-test-case).
+> Before you begin, ensure that you have referred to the documentation for [creating test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), [test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), [environment](https://testsigma.com/docs/test-data/create-environment-data/), [test plans](https://testsigma.com/docs/runs/test-plan-executions/#steps-to-create-and-execute-test-plan) with [test data types](https://testsigma.com/docs/test-data/types/overview/), and [performing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/#steps-to-perform-ad-hoc-runs-for-a-test-case) in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-data/types/mailbox.md
+++ b/src/pages/docs/test-data/types/mailbox.md
@@ -49,7 +49,8 @@ Testsigma provides a digital inbox called Mail Box to verify OTP accuracy, check
 
 > ## **Prerequisites**
 > 
-> Before using Mailbox Test Data, ensure that you understand specific concepts such as creating a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), managing [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and effectively using them with [Test Data Types](https://testsigma.com/docs/test-data/types/overview/) and [Data Generators](https://testsigma.com/docs/test-data/types/data-generator/). Additionally, familiarise yourself with [Regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) if necessary.
+> Before you begin, ensure that you have referred to the documentation for [creating test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), [managing test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), using [test data types](https://testsigma.com/docs/test-data/types/overview/) and [data generators](https://testsigma.com/docs/test-data/types/data-generator/), and for understanding [regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).
+
 
 [[info | NOTE:]]
 | - You can enable Mail Box for your account by contacting **support@testsigma.com** or using the **instant chat** option.

--- a/src/pages/docs/test-data/types/overview.md
+++ b/src/pages/docs/test-data/types/overview.md
@@ -54,9 +54,9 @@ This documentation will explain the different test data types supported in Tests
 
 ---
 
-## **Prerequisites**
-
-Before using test data type, you must understand specific concepts such as creating [projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and [test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/).
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and [test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/).
 
 ---
 
@@ -82,7 +82,7 @@ Here is a quick GIF demonstrating the above workflow: ![Select Test Data Types](
 
 ## **Plain Text**
 
-You can use Plain Text as a test data type in Testsigma. It is perfect for entering static and fixed values in your test cases. This type is suitable for providing constant information like usernames, passwords, or text that doesn't change during testing. Raw Data, where the data is directly specified, frequently uses Plain Text test data for test steps. For more information, refer to [Plain Text - Raw Data](https://testsigma.com/docs/test-data/types/raw/).
+You can use Plain Text as a test data type in Testsigma. It is perfect for entering static and fixed values in your test cases. This type is suitable for providing constant information like usernames, passwords, or text that doesn't change during testing. Raw Data, where the data is directly specified, frequently uses Plain Text test data for test steps. For information on Plain Text, refer to the documentation on [Plain Text - Raw Data](https://testsigma.com/docs/test-data/types/raw/) in Testsigma.
 
 For example, at the start of the test case, we specify the URL to navigate as shown below:
 ![Plain Text data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/plaintext_testdata.png)
@@ -104,7 +104,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 ## **Parameter**
 
 - **Parameter Test Data** enables you to create a list of values for input during test execution and generate parameterised test cases to evaluate your application under different scenarios. This type of testing allows you to use parameters from your test data profile directly.
-- When selecting the parameter data type, you can choose the specific parameter required for your test case from a right-side panel with various available parameters. To perform data-driven testing, you can use Parameter Test Data. For more information, refer to the [Parameter Test Data Type](https://testsigma.com/docs/test-data/types/parameter/) and create [Test Data Profiles](https://testsigma.com/docs/test-data/create-data-profiles/) for [Data-driven Testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
+- When selecting the parameter data type, you can choose the specific parameter required for your test case from a right-side panel with various available parameters. To perform data-driven testing, you can use Parameter Test Data. For more information on Parameter, refer to the documentation on [parameter test data type](https://testsigma.com/docs/test-data/types/parameter/) and [create test data profiles](https://testsigma.com/docs/test-data/create-data-profiles/) for [data-driven testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
 - To use Parameter Test Data, use the **@ Parameter** type and replace the word "**Parameter**" with the specified parameter name. For example, replace test data with **@ user 1**, where **user 1** corresponds to the parameter name in the **Test Data Profile**. ![Parameter Testdata Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/parameter_testdatatypes.png)
 
 [[info | NOTE:]]
@@ -115,7 +115,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 ## **Runtime**
 
 - Use the **Store** keyword to store dynamic values, called **Runtime Variables**, that can change during a test. This keyword helps capture and reuse data within the same test Project, especially when dealing with values generated during the test.
-- You can use user-defined variables to define and manage Runtime data, and you don't need a separate interface for management. The execution of the test case is specific to the Runtime Test Data. Refer to the [Runtime Test Data](https://testsigma.com/docs/test-data/types/runtime/) for more information. ![Runtime Test Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/runtime_testdata_type.png)
+- You can use user-defined variables to define and manage Runtime data, and you don't need a separate interface for management. The execution of the test case is specific to the Runtime Test Data. For more information on Runtime, refer to the documentation on [runtime test data](https://testsigma.com/docs/test-data/types/runtime/). ![Runtime Test Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/runtime_testdata_type.png)
 - Use a runtime data parameter to check a web page's title before and after a page reload. First, use a command to store the title in a runtime data parameter called "**Travel**". Then, verify the page title after reloading the page using the stored parameter with the statement You should see the page title as **$ Travel**.
 
 ---
@@ -124,7 +124,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 
 - Manage Environment Test Data Type on the Environments page with a limited scope to a project. The Environment Test Data Type contains environment-related information like URLs, API endpoints, and database connection details. You must configure test cases to work in various environments (e.g., development, staging, production).
 
-- You can use the *** Environment** type and substitute the parameter's name for "**Environment**" to use Testsigma's most versatile Test Data Type, the Environment Parameter. Refer to the [Environment](https://testsigma.com/docs/test-data/types/environment/) for more information. ![Environment Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/environment_testdata_type.png)
+- You can use the *** Environment** type and substitute the parameter's name for "**Environment**" to use Testsigma's most versatile Test Data Type, the Environment Parameter. For more information on Environment, refer to the documentation on [environment](https://testsigma.com/docs/test-data/types/environment/).  ![Environment Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/environment_testdata_type.png)
 
 [[info | EXAMPLE:]]
 | During executions, you can access separate Environment sets to store URLs and login details for environments like Production, Testing, Development, UAT, or Staging servers.
@@ -133,7 +133,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 
 ## **Random**
 
-Random Test Data Type generates random data such as numbers, email addresses, and passwords to add variety to your tests and create diverse test scenarios with unpredictable data. You can use the format **~ Random** and replace **~ Random** with an integer value from 1 to 256 to generate random values for Test Case execution. During Test Case Execution, you can specify the length of the alphanumeric character you want to receive by providing an integer value. Refer to the [Random Test Data](https://testsigma.com/docs/test-data/types/random/) for more information. ![Random Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/random_testdata_type.png)
+Random Test Data Type generates random data such as numbers, email addresses, and passwords to add variety to your tests and create diverse test scenarios with unpredictable data. You can use the format **~ Random** and replace **~ Random** with an integer value from 1 to 256 to generate random values for Test Case execution. During Test Case Execution, you can specify the length of the alphanumeric character you want to receive by providing an integer value. For more information on Random, refer to the documentation on [random testdata](https://testsigma.com/docs/test-data/types/random/). ![Random Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/random_testdata_type.png)
 
 [[info | EXAMPLE:]]
 | When you use **~|25|** in your test data, you will replace it with a **25**-character-long alphanumeric string during execution. Testsigma provides a random alphanumeric string of **N** characters when you include **~|N|** in a Test Step.
@@ -142,24 +142,24 @@ Random Test Data Type generates random data such as numbers, email addresses, an
 
 ## **Data Generator**
 
-Data Generator test data type generates realistic and structured data for testing purposes, such as names, addresses, and emails. You can obtain dynamic data by using the **Default Test Data Generator Functions**. To use them, you must substitute "**Data Generator**" with the specific name required in the **! Data Generator** format. Refer to the [Data Generator](https://testsigma.com/docs/test-data/types/data-generator/) for more information. ![Data Generator Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/datagenerator_datatype.png)
+Data Generator test data type generates realistic and structured data for testing purposes, such as names, addresses, and emails. You can obtain dynamic data by using the **Default Test Data Generator Functions**. To use them, you must substitute "**Data Generator**" with the specific name required in the **! Data Generator** format. For more information on Data Generator, refer to the documentation on [data generator](https://testsigma.com/docs/test-data/types/data-generator/). ![Data Generator Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/datagenerator_datatype.png)
 
 ---
 
 ## **Phone Number**
 
-Phone Number test data type allows you to create random or predefined phone numbers for testing SMS or phone number validation features. If you need a valid phone number to receive SMS codes for scenarios like two-factor authentication testing, Testsigma provides a test phone number that you can use as test data in your test steps. Refer to the [Phone Number](https://testsigma.com/docs/test-data/types/phone-number/) and [2-step Authentication](https://testsigma.com/tutorials/advanced/sms-based-two-factor-authentication-2fa/) for more information. ![Phone Number Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/phonenumber_testdatatype.png)
+Phone Number test data type allows you to create random or predefined phone numbers for testing SMS or phone number validation features. If you need a valid phone number to receive SMS codes for scenarios like two-factor authentication testing, Testsigma provides a test phone number that you can use as test data in your test steps. For more information on Phone Numbers, refer to the documentation on [phone number](https://testsigma.com/docs/test-data/types/phone-number/) and [2-step authentication](https://testsigma.com/tutorials/advanced/sms-based-two-factor-authentication-2fa/). ![Phone Number Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/phonenumber_testdatatype.png)
 
 ---
 
 ## **Mail Box**
 
-Mailbox test data type generates email addresses and mailbox data for testing email-related functions, particularly for workflows involving OTPs or activation links. Testsigma enables you to use provisioned mailbox email addresses to input test data. Refer to the [Mail Box](https://testsigma.com/docs/test-data/types/mailbox/) for more information. ![Mail Box Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/mailbox_testdatatype.png)
+Mailbox test data type generates email addresses and mailbox data for testing email-related functions, particularly for workflows involving OTPs or activation links. Testsigma enables you to use provisioned mailbox email addresses to input test data. For more information on Mail Box, refer to the documentation on [mail box](https://testsigma.com/docs/test-data/types/mailbox/). ![Mail Box Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/mailbox_testdatatype.png)
 
 ---
 
 ## **Upload**
 
-Upload test data type enables you to easily upload files and applications to your tests using NLP, streamlining the process of adding attachments to your test cases. Refer to the [Upload Files](https://testsigma.com/docs/uploads/upload-files/) & [Apps](https://testsigma.com/docs/uploads/upload-apps/) for more information. ![Upload data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/upload_testdata_type.png)
+Upload test data type enables you to easily upload files and applications to your tests using NLP, streamlining the process of adding attachments to your test cases. For more information on Upload, refer to the documentation on [upload files](https://testsigma.com/docs/uploads/upload-files/) & [apps](https://testsigma.com/docs/uploads/upload-apps/). ![Upload data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/upload_testdata_type.png)
 
 ---

--- a/src/pages/docs/test-data/types/runtime.md
+++ b/src/pages/docs/test-data/types/runtime.md
@@ -10,6 +10,9 @@ contextual_links:
 - type: section
   name: "Contents"
 - type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
   name: "Store Data as a Runtime Variable"
   url: "#store-data-as-a-runtime-variable"
 - type: link
@@ -25,9 +28,10 @@ contextual_links:
 In Testsigma, Runtime Test Data allows you to save data gathered while running a Test Case. For example, you can utilise the Runtime Test Data Type to copy data from one page and confirm its presence on another page. The Runtime Test Data Type in Testsigma lets you dynamically store and use data during the test. You can keep this data as a runtime variable, making automated tests more flexible and adaptable.
 
 ---
-### **Prerequisites**
 
-Before using Runtime Test Data, ensure you understand specific concepts such as creating a [Project](https://testsigma.com/docs/projects/overview/), [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), and [Elements](https://testsigma.com/docs/elements/overview/), managing [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and effectively using them with [Test Data Types](https://testsigma.com/docs/test-data/types/overview/).
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating a project](https://testsigma.com/docs/projects/overview/), [test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), [elements](https://testsigma.com/docs/elements/overview/), managing [test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and using them with [test data types](https://testsigma.com/docs/test-data/types/overview/).
 
 ---
 

--- a/src/pages/docs/test-plans/after-test.md
+++ b/src/pages/docs/test-plans/after-test.md
@@ -25,7 +25,7 @@ contextual_links:
 
 AfterTest in Testsigma lets you create a block of steps after the test case as well as add a step group to execute irrespective of the result of the test case. Both test case and after test blocks execute independently. This article will discuss how to enable and use after test in test cases and step groups. 
 
-*For more information on Test Cases, refer to [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
+*For more information on Test Cases, refer to the documentation on [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
 
 
 ---

--- a/src/pages/docs/test-plans/cross-browser-testing.md
+++ b/src/pages/docs/test-plans/cross-browser-testing.md
@@ -27,7 +27,7 @@ Cross Browser Testing is testing web applications across multiple browsers to en
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/), [test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-plans/distributed-testing.md
+++ b/src/pages/docs/test-plans/distributed-testing.md
@@ -34,7 +34,7 @@ Distributed testing is achieved in Testsigma by splitting up test plan execution
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for [creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/),  [test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and  [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-plans/email-configuration.md
+++ b/src/pages/docs/test-plans/email-configuration.md
@@ -26,7 +26,7 @@ Setting up email notifications for test plans in Testsigma helps you stay inform
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concept of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to the documentation for  [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-plans/headless-testing.md
+++ b/src/pages/docs/test-plans/headless-testing.md
@@ -37,7 +37,7 @@ This guide will explain how to do headless browser testing in Testsigma. It will
 
 > ## **Prerequisites**
 >
-> Before using the Headless browser testing feature, you should understand the concepts of [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/), [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/), and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
+> Before you begin, ensure that you have referred to the documentation for [projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test plans](https://testsigma.com/docs/test-management/test-plans/overview/),  [Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/), and [test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. 
 
 [[info | NOTE:]]
 | Headless testing can test web applications

--- a/src/pages/docs/test-plans/manage-test-machines.md
+++ b/src/pages/docs/test-plans/manage-test-machines.md
@@ -32,7 +32,7 @@ While creating a test plan, you must add at least one test machine to a test sui
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/) and [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to the documentation for [creating test suite](https://testsigma.com/docs/test-management/test-suites/overview/) and a [test plan](https://testsigma.com/docs/test-management/test-plans/overview/). 
 
 
 ---

--- a/src/pages/docs/test-plans/manage-test-suites.md
+++ b/src/pages/docs/test-plans/manage-test-suites.md
@@ -25,11 +25,9 @@ While creating a test plan, you need to add at least one test suite to the test 
 
 ---
 
-## **Prerequisites**
-
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/), [test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
 
 
 ---

--- a/src/pages/docs/test-plans/overview.md
+++ b/src/pages/docs/test-plans/overview.md
@@ -34,7 +34,7 @@ In Testsigma, the Test Plan helps plan and organise software testing. The Test P
 
 > ## **Prerequisites**
 >
-> Before using a Test Plan, you must understand specific concepts, such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and [test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
 
 ---
 
@@ -57,17 +57,17 @@ In Testsigma, the Test Plan helps plan and organise software testing. The Test P
     - **Labels**: You can label the Test Plan. Labels make it easier to manage multiple Test Plans, as they help with sorting and grouping.
     - **Test Plan Type**: Select either the test plan type: **Cross Browser Testing** (Use single/ multiple browsers to test all the test suites; for more information, refer to [Cross Browser Testing](https://testsigma.com/docs/test-management/test-plans/cross-browser-testing/)) or **Custom Test Plan** (Manually add test machine profiles to individual test suites).
 3. In the **Add Test Suites & Link Machine Profiles** tab, provide the following details and then click **Continue**:
-    - Click **Add Test Suites** to include test suites in the test plan (for more information, refer to [Manage Test Suites in Test Plan](https://testsigma.com/docs/test-management/test-plans/manage-test-suites/)).
-    - Next, click the **Test Machine** icon to add machine profiles to the test plan. An overlay will appear, and you can select a pre-defined machine or create a new test machine. Once you have selected, click **Save Selection** (for more information, refer to [Manage Test Machines in Test Plan](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/)).
+    - Click **Add Test Suites** to include test suites in the test plan (for more information on how to manage test suites in test plan, refer to the documentation on [manage test suites in test plan](https://testsigma.com/docs/test-management/test-plans/manage-test-suites/)).
+    - Next, click the **Test Machine** icon to add machine profiles to the test plan. An overlay will appear, and you can select a pre-defined machine or create a new test machine. Once you have selected, click **Save Selection** (for more information on how to manage test machines in test plans, refer to the documentation on [manage test machines in test plan](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/)).
 4. In the **Test Plan Settings** tab, provide the following details, and click **Create**:
-    - **Send Notification**: Enable the toggle for Send Notification and specify when to receive the notifications (for example, select to receive notifications when your test plans are **Passed**, **Failed**, **Not Executed**, **Queued**, **Stopped**, or **Running**. You can enter the emails or check the box to **Add my email** for receiving notifications through email. Messages can also be sent to collaboration tools like Google Chat, Slack, or MS Teams.
+    - **Send Notification**: Enable the toggle for Send Notification and specify when to receive the notifications (for example, select to receive notifications when your test plans are **Passed**, **Failed**, **Not Executed**, **Queued**, **Stopped**, or **Running**). You can enter the emails or check the box to **Add my email** for receiving notifications through email. Messages can also be sent to collaboration tools like Google Chat, Slack, or MS Teams.
     - **Additional Settings**: Provide the following details under additional settings:
         - **Environment**: Select the test environment.
         - **Screenshot Capture**: Select when the screenshots need to be taken, for **None**, **All Steps** or **Failed Steps alone**.
         - **Page Timeout**: Duration for which the test should wait for the page to load.
         - **Element Timeout**: Duration for which the test should wait for the element to load.
     - **Recovery Actions**: Click **Recovery Actions** to open the recovery actions section and define what actions should happen.
-    - **Post Plan Hook**: Select the Post Plan Hook and define actions or tasks to be performed once the test plan is executed and conditions are met (for more information, refer to [Post Plan Hook](https://testsigma.com/docs/test-management/test-plans/post-plan-hook/)).
+    - **Post Plan Hook**: Select the Post Plan Hook and define actions or tasks to be performed once the test plan is executed and conditions are met (for more information on post plan hook, refer to the documentation on [post plan hook](https://testsigma.com/docs/test-management/test-plans/post-plan-hook/)).
 ![Create Test Plan](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/creatinga_testplan.gif)
 
 ---
@@ -86,9 +86,9 @@ In Testsigma, the Test Plan helps plan and organise software testing. The Test P
 4. In the **Test Machine & Suites** tab, you can view **Machine Name**, **Configuration**, **No of Suites**, **Parallel Settings** and **Session Settings** on the Test Suites details page.
     - Click the **ellipsis** icon and select **Edit** or **Delete** to manage the Test Machine.
     - **Toggle** the Test Machine switch in the test plan to turn the test machine on or off.
-    - Click the **Search** icon to search for a test machine in the test plan, and then click **Add Machine** to add a new Test Machine to the plan (for more information, refer to the [Manage Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/)).
-5. In the **CI/CD Integrations** tab, view **Default Integrations tools** and **Rest API to integrate with other tools** (for more information, refer to the [Integrations](https://testsigma.com/docs/integrations/overview/)).
-6. In the **Schedules** tab, view **Test Plan Schedules**, and you can edit and delete the schedules (for more information, refer to the [Schedule Test Plans](https://testsigma.com/docs/test-management/test-plans/schedule-plans/)). ![Manage Test Plan](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/manage_testplan.gif)
+    - Click the **Search** icon to search for a test machine in the test plan, and then click **Add Machine** to add a new Test Machine to the plan (for more information on how to manage test machines, refer to the documentation on [manage test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/)).
+5. In the **CI/CD Integrations** tab, view **Default Integrations tools** and **Rest API to integrate with other tools** (for more information on integrations, refer to the documentation on [integrations](https://testsigma.com/docs/integrations/overview/)).
+6. In the **Schedules** tab, view **Test Plan Schedules**, and you can edit and delete the schedules (for more information on how to schedule test plans, refer to the documentation on [schedule test plans](https://testsigma.com/docs/test-management/test-plans/schedule-plans/)). ![Manage Test Plan](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/manage_testplan.gif)
 
 ---
 

--- a/src/pages/docs/test-plans/partial-test-plan-run-via-api.md
+++ b/src/pages/docs/test-plans/partial-test-plan-run-via-api.md
@@ -10,6 +10,9 @@ contextual_links:
 - type: section
   name: "Contents"
 - type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
   name: "Configure Partial Test Plan Run"
   url: "#configure-partial-test-plan-run"
 - type: link
@@ -28,10 +31,9 @@ contextual_links:
 
 Performing a partial run in a test plan via an API call in Testsigma enables you to execute specific test suites and apply filters programmatically, providing flexibility and automation in your testing workflow. This documentation will guide you through configuring a partial test plan run, executing it via an API call, and scheduling the partial run for future execution.
 
-Ensure you fulfil the following prerequisites before proceeding with the steps:
-- Create a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/) 
-- Obtain an [API key for Authorization](https://testsigma.com/docs/configuration/api-keys/) 
-- [Get Test Plan ID](https://testsigma.com/docs/continuous-integration/get-test-plan-details/)
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/), [obtaining an API key for authorization](https://testsigma.com/docs/configuration/api-keys/) , and [getting the test plan ID](https://testsigma.com/docs/continuous-integration/get-test-plan-details/).
 
 ---
 

--- a/src/pages/docs/test-plans/run-tests-in-parallel.md
+++ b/src/pages/docs/test-plans/run-tests-in-parallel.md
@@ -29,7 +29,7 @@ Executing tests in parallel significantly improves testing efficiency by reducin
 
 > ## **Prerequisites**
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to the documentation for [creating a test plan](https://testsigma.com/docs/test-management/test-plans/overview/), [test suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-plans/schedule-plans.md
+++ b/src/pages/docs/test-plans/schedule-plans.md
@@ -34,7 +34,7 @@ In Testsigma, you can schedule your test plans to automate their execution and m
 
 > ## **Prerequisites**
 >
-> Before you schedule a test plan in Testsigma, you must understand the concepts of creating the [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to the documentation for [creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/) before scheduling a test plan in Testsigma.
 
 ---
 

--- a/src/pages/docs/test-suites/dynamic-test-suites.md
+++ b/src/pages/docs/test-suites/dynamic-test-suites.md
@@ -37,9 +37,10 @@ Dynamic Test Suites in Testsigma provide an efficient way to streamline test exe
 
 ---
 
-## **Prerequisites**
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for understanding the concept of [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
 
-Before you begin, ensure that you are familiar with the concept of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma. 
 
 ---
 

--- a/src/pages/docs/test-suites/overview.md
+++ b/src/pages/docs/test-suites/overview.md
@@ -34,7 +34,7 @@ Organise your test cases into test suites based on common functionalities or sce
 
 ## **Prerequisites**
 
-Ensure that you create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in the Same [Project](https://testsigma.com/docs/projects/overview/) before you can manage test suites in Testsigma.
+Before you begin, ensure that you have referred to the documentation for [creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in the same  [project](https://testsigma.com/docs/projects/overview/) in Testsigma.  
 
 ---
 

--- a/src/pages/docs/uploads/upload-apps.md
+++ b/src/pages/docs/uploads/upload-apps.md
@@ -29,7 +29,7 @@ This guide will demonstrate how to do this and automate your mobile app testing,
 ---
 ### **Prerequisites**
 
-Before uploading the Android and iOS applications, you must understand specific concepts, such as creating [Projects](https://testsigma.com/docs/projects/overview/) and [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and uploading the **Android** app as a **.apk** file and the **iOS** app as a **.ipa** file for testing.
+Before uploading the Android and iOS applications, ensure that you have referred to the documentation for [projects](https://testsigma.com/docs/projects/overview/) and [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and uploading the **Android** app as a **.apk** file and the **iOS** app as a **.ipa** file for testing.
 
 ---
 

--- a/src/pages/docs/visual-testing/configure-test-steps.md
+++ b/src/pages/docs/visual-testing/configure-test-steps.md
@@ -41,9 +41,10 @@ Testsigma allows you to check your app's appearance during tests using its Visua
 
 ---
 
-## **Prerequisites**
+> ## **Prerequisites**
+> 
+> Before you begin, ensure that you have referred to the documentation for [creating projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), utilising [test step options](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-settings/), [Ad-Hoc run](https://testsigma.com/docs/runs/adhoc-runs/), and [test case - advanced options](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#test-case----advanced-options).
 
-Before using Visual Testing, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), utilising [Test Step Options](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-settings/), [Ad-hoc Run](https://testsigma.com/docs/runs/adhoc-runs/), and [Test Case - Advanced Options](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#test-case----advanced-options).
 
 ---
 

--- a/src/pages/docs/visual-testing/visual-testing-with-figma-designs.md
+++ b/src/pages/docs/visual-testing/visual-testing-with-figma-designs.md
@@ -32,7 +32,7 @@ You can now compare test execution screenshots with original design files in Fig
 
 > ## **Prerequisites**
 > 
-> Before you begin, make sure you know how to configure test steps for visual testing in Testsigma. For more information, see [Visual Testing](https://testsigma.com/docs/visual-testing/configure-test-steps/).
+> Before you begin, ensure that you have referred to the documentation for  [configuring test steps for visual testing](https://testsigma.com/docs/visual-testing/configure-test-steps/) in Testsigma.
 
 ---
 


### PR DESCRIPTION

Updated the SEO keywords internal linking in Docs as per the ticket: https://testsigma.atlassian.net/browse/DOC-349

<img width="1722" height="1038" alt="image" src="https://github.com/user-attachments/assets/0892a514-4eeb-47fd-b5bd-d441bc4356c0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized “Prerequisites” across docs to a consistent, blockquote-styled note.
  - Reworded guidance to direct users to relevant documentation (e.g., creating test cases, test plans, machines) with clearer, lowercased link labels.
  - Expanded and corrected cross-references throughout best practices, test data, test plans, integrations, and GenAI sections.
  - Added/updated Contents navigation items (e.g., new Prerequisites anchors) for easier discovery.
  - Improved terminology consistency (e.g., REST API, shadow DOM, headless testing) and clarified instructions in step type and visual testing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->