### PR TITLE
Updated SEO keywords internal linking in Docs

### DIFF
--- a/src/pages/docs/FAQs/web-apps/failure-to-link-text-capture.md
+++ b/src/pages/docs/FAQs/web-apps/failure-to-link-text-capture.md
@@ -30,9 +30,11 @@ In automated testing, test failures often occur when the recorder captures link 
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before you proceed, ensure you know how to create or update an [Element](https://testsigma.com/docs/elements/web-apps/create-manually/) and a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on updating elements](https://testsigma.com/docs/elements/web-apps/create-manually/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/FAQs/web-apps/viewing-full-testplan-execution-video.md
+++ b/src/pages/docs/FAQs/web-apps/viewing-full-testplan-execution-video.md
@@ -26,8 +26,11 @@ When you enable the **Reset session for every test case** option in **Parallel S
 ---
 
 > <p id="prerequisites">Prerequisites</p>
->
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> 
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/accessibility-testing/accessibility-testing.md
+++ b/src/pages/docs/accessibility-testing/accessibility-testing.md
@@ -30,7 +30,10 @@ With Testsigma, you can easily implement accessibility testing to comply with ac
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to: 
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/accessibility-testing/mobile-accessibility-testing.md
+++ b/src/pages/docs/accessibility-testing/mobile-accessibility-testing.md
@@ -32,7 +32,10 @@ With Testsigma, you can implement accessibility testing for Android and iOS appl
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suite](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/atto/generative-ai/copilot/mobile-recorder.md
+++ b/src/pages/docs/atto/generative-ai/copilot/mobile-recorder.md
@@ -40,9 +40,12 @@ This article discusses test case generation for mobile applications using Testsi
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> 
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
 
 ---
 

--- a/src/pages/docs/atto/generative-ai/copilot/web-recorder.md
+++ b/src/pages/docs/atto/generative-ai/copilot/web-recorder.md
@@ -35,8 +35,11 @@ Testsigma Copilot redefines test automation with the power of generative AI 🤖
 ---
 
 > <p id="prerequisites">Prerequisites</p>
+>
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
 
 
 ---

--- a/src/pages/docs/best-practices/best-practices.md
+++ b/src/pages/docs/best-practices/best-practices.md
@@ -70,7 +70,7 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 1. You define the expected outcomes of automated test cases and specify the validations to be performed at specific points in time as verifications to understand the concept of assertions.
 2. Navigate to **Help** > **Actions List** on the Test Case details page to find **NLPs** with assertions in Testsigma. ![Action Lists](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/action_list.png)
 3. A failed verification in a test case marks the overall test case as failed by default. If validation fails, the remaining test steps will be skipped, and the test case execution will be aborted.
-4. To implement soft assertions for scenarios that require execution of remaining steps after a test step failure, follow the steps below and for more information, refer to [test step settings](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-recorder/step-settings/):
+4. To implement soft assertions for scenarios that require execution of remaining steps after a test step failure, follow the steps below and for more information on managing test step settings, refer to the [documentation on managing test step settings](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-recorder/step-settings/):
      - Hover over the test step, click **Option**, and choose **Step Settings** from the dropdown.
      - Uncheck **Stop Test Case execution on Test Step failure** and click **Update**.
      - You can configure specific steps to continue executing even if verification fails.
@@ -89,7 +89,7 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 ## **Customisation and Extensibility**
 
 1. You can use **add-ons to extend Testsigma's repository** of actions and create custom NLPs for specific actions that are not available in the built-in Actions List.
-2. Share your add-ons or leverage existing ones with the test automation community through the Add-ons Community Marketplace. You can use add-ons to provide additional functionality and expand the capabilities of Testsigma. For more information, refer to [create an add-on](https://testsigma.com/docs/addons/create/).
+2. Share your add-ons or leverage existing ones with the test automation community through the Add-ons Community Marketplace. You can use add-ons to provide additional functionality and expand the capabilities of Testsigma. For more information on creating an add-on, refer to the [documentation on creating an add-on](https://testsigma.com/docs/addons/create/).
 
 [[info | Example:]]
 | You create an add-on for verifying text from two DOM elements.
@@ -98,24 +98,24 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Reusability and Modularity**
 
-1. To avoid duplication and simplify test maintenance, use **Step Groups** as common reusable functions across test cases. Step Groups promote modular test design and easy maintenance by separating reusable components from the test flow. Any changes made to a Step Group will be reflected in all test cases that invoke it. For more information, refer to [step sroups](https://testsigma.com/docs/test-cases/step-types/step-group/).
+1. To avoid duplication and simplify test maintenance, use **Step Groups** as common reusable functions across test cases. Step Groups promote modular test design and easy maintenance by separating reusable components from the test flow. Any changes made to a Step Group will be reflected in all test cases that invoke it. For more information on creating step groups, refer to the [documentation on creating step sroups](https://testsigma.com/docs/test-cases/step-types/step-group/).
 
 [[info | Example:]]
 | Create a Step Group to reuse login functionality in multiple test cases.
 
-2. Use **REST API Steps** to automate redundant UI actions. Performing these actions through REST API steps will improve test stability and reduce test execution time compared to using the UI. For more information, refer to [Rest API](https://testsigma.com/docs/test-cases/step-types/rest-api/).
+2. Use **REST API Steps** to automate redundant UI actions. Performing these actions through REST API steps will improve test stability and reduce test execution time compared to using the UI. For more information on creating rest API, refer to the [documentation on creating rest API](https://testsigma.com/docs/test-cases/step-types/rest-api/).
 
 ---
 
 ## **Element Management**
 
-1. Create elements with proper naming conventions to enable reuse in multiple test cases. For more information, refer to [create an element](https://testsigma.com/docs/elements/web-apps/create-manually/).
+1. Create elements with proper naming conventions to enable reuse in multiple test cases. For more information on creating an element, refer to the [documentation on creating an element](https://testsigma.com/docs/elements/web-apps/create-manually/).
 
 [[info | Example:]]
 | Use descriptive names such as "UsernameInput" or "LoginButton" to make them easy to identify.
 
-2. You should map appropriate context details when you create elements inside **iFrames** or **Shadow DOM** contexts. Mapping context details will ensure you correctly identify and interact with elements within specific contexts. For more information refer to Shadow DOM Element. For more information, refer to [create a shadow DOM element](https://testsigma.com/docs/elements/web-apps/shadow-dom/#create-element-for-shadow-dom).
-3. You can easily access elements by saving filters and creating views based on screen names. They can check for the presence of elements in Testsigma's repository before recreating them. Element management is facilitated by adding filters. For more information, refer to [save element filters](https://testsigma.com/docs/elements/overview/#save-element-filter).
+2. You should map appropriate context details when you create elements inside **iFrames** or **Shadow DOM** contexts. Mapping context details will ensure you correctly identify and interact with elements within specific contexts. For more information refer to Shadow DOM Element. For more information on creating a shadow DOM element, refer to the [documentation on creating a shadow DOM element](https://testsigma.com/docs/elements/web-apps/shadow-dom/#create-element-for-shadow-dom).
+3. You can easily access elements by saving filters and creating views based on screen names. They can check for the presence of elements in Testsigma's repository before recreating them. Element management is facilitated by adding filters. For more information on saving element filters, refer to the [documentation on saving element filters](https://testsigma.com/docs/elements/overview/#save-element-filter).
 
 [[info | Example:]]
 | Create a view that displays elements related to the ''Login'' screen for quick reference.
@@ -126,15 +126,15 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 |Scope|Description|Usage|
 |---|---|---|
-|**Environment**|<li>The value stays constant during the test execution. The environment variable's values cannot be overwritten.</li><li>Any test case in any test suite can be accessed.</li><li>To create an Environment, navigate to **Test Data** > **Environments** > **Create**. For more information, refer to [environments](https://testsigma.com/docs/test-data/create-environment-data/)</li>|<li>Define base URLs or configuration settings specific to the environment.</li><li>Create test steps using the data type <strong>* url</strong>.</li><li>Example: //button[text()=’*\|url\|’]</li>|
-|**Runtime**|The values are the same throughout a sequential test run; other tests can update them. For more information, refer to [runtime variable](https://testsigma.com/docs/test-data/types/runtime/).|<li>During test execution, store session-specific data or dynamic values.</li><li>Create test steps using the data type <strong>$ divText</strong>.</li><li>Example: //button[text()=’$\|divText\|’] </li>|
-|**Test Data Profile**|<li>You can link specific test cases. You can update the values in test data profiles from other test cases.</li><li>To create a Test Data Profile, navigate to **Test Data** > **Test Data Profile** > **Create**. For more information, refer to [test data profile](https://testsigma.com/docs/test-data/create-data-profiles/)</li>|<li>Use data-driven testing and maintain test data sets.</li><li>Create test steps using the data type **@ username**.</li><li>Example: //button[text()=’@\|username\|’]</li>|
+|**Environment**|<li>The value stays constant during the test execution. The environment variable's values cannot be overwritten.</li><li>Any test case in any test suite can be accessed.</li><li>To create an Environment, navigate to **Test Data** > **Environments** > **Create**. For more information on creating environments, refer to the [documentation on creating environments](https://testsigma.com/docs/test-data/create-environment-data/)</li>|<li>Define base URLs or configuration settings specific to the environment.</li><li>Create test steps using the data type <strong>* url</strong>.</li><li>Example: //button[text()=’*\|url\|’]</li>|
+|**Runtime**|The values are the same throughout a sequential test run; other tests can update them. For more information on creating runtime variable, refer to the [documentation on creating runtime variable](https://testsigma.com/docs/test-data/types/runtime/).|<li>During test execution, store session-specific data or dynamic values.</li><li>Create test steps using the data type <strong>$ divText</strong>.</li><li>Example: //button[text()=’$\|divText\|’] </li>|
+|**Test Data Profile**|<li>You can link specific test cases. You can update the values in test data profiles from other test cases.</li><li>To create a Test Data Profile, navigate to **Test Data** > **Test Data Profile** > **Create**. For more information on creating test data profile, refer to the [documentation on creating test data profile](https://testsigma.com/docs/test-data/create-data-profiles/)</li>|<li>Use data-driven testing and maintain test data sets.</li><li>Create test steps using the data type **@ username**.</li><li>Example: //button[text()=’@\|username\|’]</li>|
 
 ---
 
 ## **Data-Driven Testing**
 
-1. Enable the data-driven toggle in test cases and use Test Data Profiles to perform the same action with different test data sets for data-driven testing. For more information, refer to [data driven testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
+1. Enable the data-driven toggle in test cases and use Test Data Profiles to perform the same action with different test data sets for data-driven testing. For more information on data driven testing, refer to the [documentation on data driven testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
 2. Test Data Profiles use key-value pair format to store project configuration data, database connection details, and project settings for easy access and reuse of test data.
 
 [[info | Example:]]
@@ -164,13 +164,13 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Configuration for Test Execution**
 
-1. Upload attachments for test steps in **Test Data** > **Uploads** and follow the maximum file size limit of **1024 MB**. The system always considers the latest version of the uploaded file. For more information, refer to [uploads](https://testsigma.com/docs/uploads/upload-files/).
-2. Configure **Desired Capabilities** for cross-browser testing with specific browser configurations. You can configure Desired Capabilities for ad-hoc runs and test plans. For more information, refer to [desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/).
+1. Upload attachments for test steps in **Test Data** > **Uploads** and follow the maximum file size limit of **1024 MB**. The system always considers the latest version of the uploaded file. For more information on uploading files, refer to the [documentation on uploading files](https://testsigma.com/docs/uploads/upload-files/).
+2. Configure **Desired Capabilities** for cross-browser testing with specific browser configurations. You can configure Desired Capabilities for ad-hoc runs and test plans. For more information on configuring desired capabilities, refer to the [documentation on configuring desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/).
 
 [[info | Example:]]
 | Specify the desired capabilities of the targeted testing, such as browser version or device type.
 
-3. Ensure you put test cases in the Ready state before adding them to a Test Suite. Organise relevant tests into test suites for better organisation and execution. For more information, refer to [test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+3. Ensure you put test cases in the Ready state before adding them to a Test Suite. Organise relevant tests into test suites for better organisation and execution. For more information on creating test suites, refer to the [documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
 
 [[info | Example:]]
 | Create a "Login Suite" and add all relevant login-related test cases for efficient execution.
@@ -179,13 +179,13 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Execution and Test Plan Run**
 
-1. Run test case and test plan in **Headless** mode to reduce execution time and eliminate element loading time. For more information, refer to [headless browser testing](https://testsigma.com/docs/test-management/test-plans/headless-testing/).
+1. Run test case and test plan in **Headless** mode to reduce execution time and eliminate element loading time. For more information on headless browser testing, refer to the [documentation on headless browser testing](https://testsigma.com/docs/test-management/test-plans/headless-testing/).
 
 [[info | Example:]]
 | To achieve faster test execution, execute the test plan without a visible browser.
 
-2. Use the **Partial Run** option in the Test Plan to exclude consistently failing test suites from runs; you can exclude or disable tests for execution from the Test Machines & Suites Selection in the Test Plan. For more information, refer to [partial run](https://testsigma.com/docs/runs/test-plan-executions/#partial-test-runs).
-3. Use the **Schedule** feature to run the test plan automatically without manual intervention. For more information, refer to [schedule a test plan](https://testsigma.com/docs/test-management/test-plans/schedule-plans/).
+2. Use the **Partial Run** option in the Test Plan to exclude consistently failing test suites from runs; you can exclude or disable tests for execution from the Test Machines & Suites Selection in the Test Plan. For more information on performing partial run, refer to the [documentation on performing partial run](https://testsigma.com/docs/runs/test-plan-executions/#partial-test-runs).
+3. Use the **Schedule** feature to run the test plan automatically without manual intervention. For more information on scheduling a test plan, refer to the [doucmentation on scheduling a test plan](https://testsigma.com/docs/test-management/test-plans/schedule-plans/).
 
 [[info | Example:]]
 | Schedule unattended testing during non-business hours by executing the test plan.
@@ -194,7 +194,7 @@ Testsigma Automation Standards emphasise the reusability of automated test cases
 
 ## **Testsigma Recorder Extension**
 
-1. Use the Testsigma Recorder Extension to record user interactions on web applications. Customise and modify the recorded test steps to align with the desired test case behaviour. For more information, refer to [recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
+1. Use the Testsigma Recorder Extension to record user interactions on web applications. Customise and modify the recorded test steps to align with the desired test case behaviour. For more information on recording test steps, refer to the [documentation on recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
 2. Use the **Automatic Element Identification** feature of the recorder extension to easily capture elements and apply validations and verifications during recording to ensure that test steps include necessary assertions.
 
 ---

--- a/src/pages/docs/collaboration/elements-review-management.md
+++ b/src/pages/docs/collaboration/elements-review-management.md
@@ -35,8 +35,11 @@ There are two ways to review an element:
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> 
-> Before using **Test Case Review Management**, you must understand specific concepts such as creating [Elements](https://testsigma.com/docs/elements/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and managing [Users and Roles](https://testsigma.com/docs/collaboration/users-roles/). Also, make sure the option **Element Review Management** is enabled under **Settings > Preferences**.
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating elements](https://testsigma.com/docs/elements/overview/).
+> 3. [Documentation on managing users and roles](https://testsigma.com/docs/collaboration/users-roles/). 
+> 4. Also, make sure the option **Element Review Management** is enabled under **Settings > Preferences**.
 
 
 ---

--- a/src/pages/docs/collaboration/test-cases-review-management.md
+++ b/src/pages/docs/collaboration/test-cases-review-management.md
@@ -39,8 +39,10 @@ This documentation will guide you through enabling and using Test Case Review Ma
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> 
-> Before using Test Case Review Management, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and managing [Users and Roles](https://testsigma.com/docs/collaboration/users-roles/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on creating users and roles](https://testsigma.com/docs/collaboration/users-roles/).
 
 ---
 

--- a/src/pages/docs/continuous-integration/copado-integration.md
+++ b/src/pages/docs/continuous-integration/copado-integration.md
@@ -23,8 +23,11 @@ Testsigma Copado integration allows you to trigger test plan execution every tim
 ---
 
 > <p id="prerequisites">Prerequisites</p>
-> 
->    - Before you begin, ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) for Salesforce, [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) for Salesforce, and [Generating API Keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key) in Testsigma.
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 3. [Documentation on generating API keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key). 
 
 ---
 

--- a/src/pages/docs/continuous-integration/gearset.md
+++ b/src/pages/docs/continuous-integration/gearset.md
@@ -24,7 +24,10 @@ Testsigma Gearset integration allows you to trigger test plan execution every ti
 
 > <p id="prerequisites">Prerequisites</p>
 > 
->    - Before you begin, ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) for Salesforce, [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) for Salesforce, and [Generating API Keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key) in Testsigma.
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 2. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 3. [Documentation on creating generating API keys](https://testsigma.com/docs/configuration/api-keys/#steps-to-generate-api-key). 
 
 ---
 

--- a/src/pages/docs/desired-capabilities/basic-authentication-safari.md
+++ b/src/pages/docs/desired-capabilities/basic-authentication-safari.md
@@ -28,8 +28,11 @@ Safari restricts automated Basic Authentication login by blocking credentials in
 ---
 
 > <p id="prerequisites">Prerequisites</p>
-> 
-> Before you begin, ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/), and [Desired Capabilities](https://testsigma.com/docs/desired-capabilities/overview/) in Testsigma.
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on performing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/).
+> 3. [Documentation on managing desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/desired-capabilities/emulate-mobile-devices-with-chrome.md
+++ b/src/pages/docs/desired-capabilities/emulate-mobile-devices-with-chrome.md
@@ -51,7 +51,7 @@ This is possible by specifying the device name in the Desired Capabilities while
 ---
 ##**Using available Devices for emulation**
 
-You should already know how to add Desired Capabilities to your Tests. See [Desired Capabilities - Overview.](https://testsigma.com/docs/desired-capabilities/overview/)
+You should already know how to add Desired Capabilities to your Tests. Refer to the [documentation on managing desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/).
 
 Select the latest version of Google Chrome for your preferred OS and enter the following values below the Desired Capabilities field:
 

--- a/src/pages/docs/desired-capabilities/enable-browser-console-logs.md
+++ b/src/pages/docs/desired-capabilities/enable-browser-console-logs.md
@@ -30,9 +30,13 @@ Browser Console Debug logs can help you more effectively identify and troublesho
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before you begin, grasp the basics of creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) and performing [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/) and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 2. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 3. [Documentation on performing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/).
+> 4. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/desired-capabilities/incognito-mode.md
+++ b/src/pages/docs/desired-capabilities/incognito-mode.md
@@ -29,9 +29,13 @@ Desired Capabilities allow you to customise the test environment by adding brows
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before starting testing in Incognito/Private Mode, you must understand specific concepts, such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/), managing [Ad-hoc runs](https://testsigma.com/docs/runs/adhoc-runs/) and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 3. [Documentation on managing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/).
+> 4. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
 
 ---
 

--- a/src/pages/docs/desired-capabilities/network-logs.md
+++ b/src/pages/docs/desired-capabilities/network-logs.md
@@ -32,9 +32,14 @@ This documentation will guide you on how to enable the network log in Test Case 
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before starting, understand the concepts of [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/), [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/), and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma. Familiarising yourself with these concepts will make working with the Network Log feature easier.
+> #<p id="prerequisites">Prerequisites</p>
+> 
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 4. [Documentation on creating Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/).
+> 5. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/). 
 
 [[info | Note:]]
 | By default, Network Log is enabled for Web and Mobile Web applications, but for Android and iOS applications, you need to enable it manually.

--- a/src/pages/docs/elements/dynamic-elements/with-runtime-test-data.md
+++ b/src/pages/docs/elements/dynamic-elements/with-runtime-test-data.md
@@ -28,9 +28,14 @@ Dynamic locators are essential in handling web elements that may undergo attribu
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before implementing dynamic locators using Runtime in Testsigma, ensure you have a solid understanding of key concepts such as creating a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), managing [Runtime Test Data](https://testsigma.com/docs/test-data/types/runtime/) and [Elements](https://testsigma.com/docs/elements/web-apps/capture-single-element/), handling [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and effectively utilising different [Test Data Types](https://testsigma.com/docs/test-data/types/overview/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case).
+> 2. [Documentation on managing runtime test data](https://testsigma.com/docs/test-data/types/runtime/).
+> 3. [Documentation on creating elements](https://testsigma.com/docs/elements/web-apps/capture-single-element/).
+> 4. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
+> 5. [Documentation on creating test data types](https://testsigma.com/docs/test-data/types/overview/).
 
 ---
 

--- a/src/pages/docs/elements/web-apps/shadow-dom.md
+++ b/src/pages/docs/elements/web-apps/shadow-dom.md
@@ -30,9 +30,14 @@ Shadow DOM elements allow you to encapsulate and isolate styling and functionali
 To perform reliable tests, you need to find these elements. This guide will explain how Testsigma can help you locate and capture Shadow DOM elements for effective testing.
 
 ---
+
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you begin, ensure that you understand specific concepts such as creating [projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [elements](https://testsigma.com/docs/elements/overview/), and [recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/). 
+> 3. [Documentation on creating elements](https://testsigma.com/docs/elements/overview/).
+> 4. [Documentation on recording test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/#creating-test-steps-using-test-recorder).
 
 ---
 

--- a/src/pages/docs/genai-capabilities/copilot.md
+++ b/src/pages/docs/genai-capabilities/copilot.md
@@ -36,8 +36,9 @@ Testsigma Copilot redefines test automation with the power of generative AI 🤖
 
 > <p id="prerequisites">Prerequisites</p>
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
-
+> Before you begin, ensure that:
+> 1. You have enabled AI Features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/genai-capabilities/generate-tdp.md
+++ b/src/pages/docs/genai-capabilities/generate-tdp.md
@@ -24,9 +24,12 @@ With Testsigma Copilot, you can quickly generate a Test Data Profile. This elimi
 ---
 
 > <p id="prerequisites">Prerequisites</p>
+>
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Data Profiles](https://testsigma.com/docs/test-data/create-data-profiles/) in Testsigma.
-
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 3. You have referred to the [documentation on creating test data profiles](https://testsigma.com/docs/test-data/create-data-profiles/). 
 
 ---
 

--- a/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-figma-designs.md
@@ -44,8 +44,10 @@ With Testsigma, you can effortlessly generate test cases directly from Figma des
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you begin, enable AI features from **Settings > Preferences > Generative AI features** and ensure you are familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
-
+> 
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
 
 ---
 

--- a/src/pages/docs/genai-capabilities/generate-tests-from-requirements.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-requirements.md
@@ -30,8 +30,12 @@ With Testsigma, you can create test cases directly from Jira stories and epics b
 ---
 
 > <p id="prerequisites">Prerequisites</p>
+>
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features**, integrate [Jira with Testsigma](https://testsigma.com/docs/integrations/bug-reporting/jira/) and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on integrating Jira with Testsigma](https://testsigma.com/docs/integrations/bug-reporting/jira/).
+> 3. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 
 ---
 

--- a/src/pages/docs/genai-capabilities/generate-tests-from-user-actions.md
+++ b/src/pages/docs/genai-capabilities/generate-tests-from-user-actions.md
@@ -26,8 +26,11 @@ This article discusses generating end to end automated test cases based on user 
 ---
 
 > <p id="prerequisites">Prerequisites</p>
+>
 > 
-> Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
 
 ---
 

--- a/src/pages/docs/genai-capabilities/mobile-copilot.md
+++ b/src/pages/docs/genai-capabilities/mobile-copilot.md
@@ -43,9 +43,12 @@ This article discusses test case generation for mobile applications using Testsi
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before you begin, enable AI Features from **Settings > Preferences > Generative AI features** and ensure you're familiar with the concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> 
+> Before you begin, ensure that:
+> 1. You have enabled AI features from **Settings > Preferences > Generative AI features**.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case). 
 
 ---
 

--- a/src/pages/docs/getting-started/testsigma-sample-apps.md
+++ b/src/pages/docs/getting-started/testsigma-sample-apps.md
@@ -25,7 +25,7 @@ This article provides a few sample applications for users to practice testing in
 
     - https://mobile-simply-travel.testsigma.com/
 
-*For more information on how to create test cases, refer to [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
+*For more information on how to create test cases, refer to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
 
 
 2. Use the following apps for practicing mobile app testing.
@@ -36,7 +36,7 @@ This article provides a few sample applications for users to practice testing in
     - [SMS Forwarder Application](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/smsforward.apk)
 
 
-*For more information on uploading mobile apps for testing, refer to [upload android and iOS apps](https://testsigma.com/docs/uploads/upload-apps/).*
+*For more information on uploading mobile apps for testing, refer to the [documentation on uploading android and iOS apps](https://testsigma.com/docs/uploads/upload-apps/).*
 
 3. Use the following link for practicing API testing:
 

--- a/src/pages/docs/integrations/test-management/qtest.md
+++ b/src/pages/docs/integrations/test-management/qtest.md
@@ -36,9 +36,11 @@ qTest is a manual test management tool. With qTest integration in Testsigma, you
 ---
 
 > <p id="prerequisites">Prerequisites</p>
->
 > 
-> Before you begin, ensure you have a valid **Host URL** and **Bearer Token** from qTest. Also, make sure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma.
+> Before you begin, ensure that: 
+> 1. You have a valid **Host URL**, **Username**, and **Password** from TestRail.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. You have referred to the [documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/integrations/test-management/testrail.md
+++ b/src/pages/docs/integrations/test-management/testrail.md
@@ -38,8 +38,10 @@ You can integrate Testsigma with TestRail to streamline test management and trac
 
 > <p id="prerequisites">Prerequisites</p>
 > 
-> Before you begin, ensure you have a valid **Host URL**, **Username**, and **Password** from TestRail. Also, make sure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/) in Testsigma.
-
+> Before you begin, ensure that: 
+> 1. You have a valid **Host URL**, **Username**, and **Password** from TestRail.
+> 2. You have referred to the [documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. You have referred to the [documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/live-editor/editing-test-case.md
+++ b/src/pages/docs/live-editor/editing-test-case.md
@@ -26,9 +26,9 @@ In Testsigma, Live Editor gives you complete control over test cases while execu
 
 
 > <p id="prerequisites">Prerequisites</p>
-> 
-> Before you begin, ensure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and install **Testsigma Terminal** application.
-
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and install **Testsigma Terminal** application.
 
 ---
 

--- a/src/pages/docs/reports/runs/drill-down-reports.md
+++ b/src/pages/docs/reports/runs/drill-down-reports.md
@@ -43,7 +43,8 @@ In Testsigma, you can view and download reports from the Run Results page. This 
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you begin, make sure you have created and executed a [test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/reports/runs/filter-custom-reports.md
+++ b/src/pages/docs/reports/runs/filter-custom-reports.md
@@ -26,7 +26,8 @@ Quickly view the run results of a test plan by applying filters | Learn how to a
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you begin, make sure you have created and executed a [test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 
 ---

--- a/src/pages/docs/runs/adhoc-runs.md
+++ b/src/pages/docs/runs/adhoc-runs.md
@@ -43,9 +43,19 @@ This documentation will guide you through setting up Test Labs and Test Machines
 
 ---
 
-## **Prerequisites:**
-
-Before using the Ad-hoc Run, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/) and [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), understanding [Test Labs](https://testsigma.com/docs/test-management/test-plans/supported-test-lab-types/), setting up [Local Devices with Testsigma Agent](https://testsigma.com/docs/agent/overview/), [Environments](https://testsigma.com/docs/test-data/types/environment/#use-environment-in-ad-hoc-run-page), [Headless Tests](https://testsigma.com/docs/test-management/test-plans/headless-testing/#enabling-headless-browser-testing-in-test-case), and [Desired Capabilities](https://testsigma.com/docs/desired-capabilities/overview/) for all applications. You should also be familiar with [Uploads](https://testsigma.com/docs/uploads/upload-apps/), [Camera Image Injection](https://testsigma.com/docs/test-cases/image-injection/) and [Network Logs](https://testsigma.com/docs/desired-capabilities/network-logs/#enable-network-logs-in-test-case) for Android and iOS applications.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on creating test labs](https://testsigma.com/docs/test-management/test-plans/supported-test-lab-types/).
+> 4. [Documentation on setting up local devices with Testsigma Agent](https://testsigma.com/docs/agent/overview/).
+> 5. [Documentation on creating environments](https://testsigma.com/docs/test-data/types/environment/#use-environment-in-ad-hoc-run-page).
+> 6. [Documentation on creating headless tests](https://testsigma.com/docs/test-management/test-plans/headless-testing/#enabling-headless-browser-testing-in-test-case).
+> 7. [Documentation on managing desired capabilities](https://testsigma.com/docs/desired-capabilities/overview/) for all applications. 
+> 8. [Documentation on uploads](https://testsigma.com/docs/uploads/upload-apps/).
+> 9. [Documentation on creating camera image injection](https://testsigma.com/docs/test-cases/image-injection/).
+> 10. [Documentation on creating network logs](https://testsigma.com/docs/desired-capabilities/network-logs/#enable-network-logs-in-test-case) for Android and iOS applications.
 
 ---
 

--- a/src/pages/docs/test-cases/create-test-steps/actions-and-options-manual/step-options.md
+++ b/src/pages/docs/test-cases/create-test-steps/actions-and-options-manual/step-options.md
@@ -49,10 +49,10 @@ In Testsigma, you can customize test steps within a test case using test step op
 
 
 > <p id="prerequisites">Prerequisites</p>
->   
-> - You should know how to [manage a Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
 >
-> - You should know how to [manage Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
 
 ---
 

--- a/src/pages/docs/test-cases/image-injection.md
+++ b/src/pages/docs/test-cases/image-injection.md
@@ -26,9 +26,19 @@ Testsigma enables you to enhance your testing process by inserting images into y
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before using Image Injection, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), [Test Data Types](https://testsigma.com/docs/test-data/types/overview/), [Uploading Applications](https://testsigma.com/docs/uploads/upload-apps/), [Uploading Files](https://testsigma.com/docs/uploads/upload-files/), recording steps for [Android](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-recorder/step-settings/#reordering-test-steps) and [iOS](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-options/#reorder-test-step), and performing Ad-hoc runs in [Android](https://testsigma.com/docs/runs/adhoc-runs/#android-application) and [iOS](https://testsigma.com/docs/runs/adhoc-runs/#ios-application).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 4. [Documentation on creating test data types](https://testsigma.com/docs/test-data/types/overview/).
+> 5. [Documentation on uploading applications](https://testsigma.com/docs/uploads/upload-apps/).
+> 6. [Documentation on uploading files](https://testsigma.com/docs/uploads/upload-files/).
+> 7. [Documentation on  recording steps for android](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-recorder/step-settings/#reordering-test-steps).
+> 8. [Documentation on recording steps for iOS](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-options/#reorder-test-step).
+> 9. [Documentation on performing Ad-Hoc runs in android](https://testsigma.com/docs/runs/adhoc-runs/#android-application).
+> 10. [Documentation on performing Ad-Hoc runs in iOS](https://testsigma.com/docs/runs/adhoc-runs/#ios-application).
 
 [[info | Note:]]
 | Ensure that you upload image files in **PNG** format for Image Injection, which is exclusively available for **Android** and **iOS** apps, and allow a few seconds for the scanner to complete the image scan.

--- a/src/pages/docs/test-cases/manage/label-management.md
+++ b/src/pages/docs/test-cases/manage/label-management.md
@@ -32,8 +32,13 @@ The Label Management feature in Testsigma helps you manage labels linked to test
 
 
 > <p id="prerequisites">Prerequisites</p>
-> 
-> Before you begin, ensure you know how to create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Elements](https://testsigma.com/docs/elements/overview/), [Step Groups](https://testsigma.com/docs/test-cases/step-types/step-group/), [Test Suites](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 2. [Documentation on creating elements](https://testsigma.com/docs/elements/overview/).
+> 3. [Documentation on creating step groups](https://testsigma.com/docs/test-cases/step-types/step-group/).
+> 4. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 5. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/test-cases/step-types/block.md
+++ b/src/pages/docs/test-cases/step-types/block.md
@@ -40,7 +40,12 @@ In Testsigma, a step block can be created using two different methods:
 
 > #<p id="prerequisites">Prerequisites</p>
 > 
-> Before using the Step Block, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), and understanding [Test Step Types](https://testsigma.com/docs/test-cases/step-types/overview/) and [Bulk Actions](https://testsigma.com/docs/test-cases/create-steps-nl/bulk-actions/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/). 
+> 4. [Documentation on creating test step types](https://testsigma.com/docs/test-cases/step-types/overview/).
+> 5. [Documentation on creating bulk actions](https://testsigma.com/docs/test-cases/create-steps-nl/bulk-actions/).
 
 ---
 
@@ -71,7 +76,7 @@ Follow the below steps to add a block using the bulk action:
 
 ## **Editing a Block**
 
-Open the test case with the Step Block you want to edit. Choose the **block**, edit its **name**, and click **Update Step** to save. Click the **>** icon to view the steps within the block. To add a Test Step, click **Step Inside Block**, or click the **ellipsis** icon in the test step for perform [Test Step Options](https://testsigma.com/docs/test-cases/create-steps-nl/step-actions/). ![Edit Block](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/edit_block.gif)
+Open the test case with the Step Block you want to edit. Choose the **block**, edit its **name**, and click **Update Step** to save. Click the **>** icon to view the steps within the block. To add a Test Step, click **Step Inside Block**, or click the **ellipsis** icon in the test step to access the [documentation on adding test step options](https://testsigma.com/docs/test-cases/create-steps-nl/step-actions/). ![Edit Block](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/edit_block.gif)
 
 ---
 

--- a/src/pages/docs/test-cases/step-types/natural-language.md
+++ b/src/pages/docs/test-cases/step-types/natural-language.md
@@ -26,9 +26,12 @@ In Testsigma, you can quickly create test steps using natural language or simple
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-- You should know how to create [Test Data](https://testsigma.com/docs/test-data/types/overview/) and [Elements](https://testsigma.com/docs/elements/web-apps/overview/). 
-- You should know how to [create a Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/). 
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test data](https://testsigma.com/docs/test-data/types/overview/).
+> 3. [DOcumentation on creating elements](https://testsigma.com/docs/elements/web-apps/overview/). 
 
 ---
 

--- a/src/pages/docs/test-cases/step-types/overview.md
+++ b/src/pages/docs/test-cases/step-types/overview.md
@@ -52,17 +52,17 @@ An automated test case is a step-by-step logic that simulates user interactions 
 
 You can choose the type of test step you want to add to your test case from the panel. Read more about the different test steps and how to create them in the links below:
 
-- [Natural Language](https://testsigma.com/docs/test-cases/step-types/natural-language/)
+- [Documentation on using natural language](https://testsigma.com/docs/test-cases/step-types/natural-language/).
 
-- [REST API](https://testsigma.com/docs/test-cases/step-types/rest-api/)
+- [Documentation on using REST API](https://testsigma.com/docs/test-cases/step-types/rest-api/).
 
-- [Step Group](https://testsigma.com/docs/test-cases/step-types/step-group/)
+- [Documentation on using step groups](https://testsigma.com/docs/test-cases/step-types/step-group/).
 
-- [For Loop](https://testsigma.com/docs/test-cases/step-types/for-loop/)
+- [Documentation on using For Loop](https://testsigma.com/docs/test-cases/step-types/for-loop/).
 
-- [While Loop](https://testsigma.com/docs/test-cases/step-types/while-loop/)
+- [Documentation on using While Loop](https://testsigma.com/docs/test-cases/step-types/while-loop/).
 
-- [If Condition](https://testsigma.com/docs/test-cases/step-types/if-condition/)
+- [Documentation on using If Condition](https://testsigma.com/docs/test-cases/step-types/if-condition/).
 
 
 ---

--- a/src/pages/docs/test-cases/step-types/rest-api.md
+++ b/src/pages/docs/test-cases/step-types/rest-api.md
@@ -24,9 +24,12 @@ Software testing focuses on verifying the functionality and performance of RESTf
 Using Rest API Testing in Testsigma, you can validate the behaviour of RESTful APIs within your application. We will guide you on how to use it.
 
 ---
-#<p id="prerequisites">Prerequisites</p>
-
-Before using the Rest API in a test step, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), using [Test Step Types](https://testsigma.com/docs/test-cases/step-types/overview/) and understanding [RESTful API Testing](https://testsigma.com/docs/test-cases/create-steps-restapi/restful-api-overview/).
+> <p id="prerequisites">Prerequisites</p>
+> 
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on RESTful API testing](https://testsigma.com/docs/test-cases/create-steps-restapi/restful-api-overview/).
 
 ---
 

--- a/src/pages/docs/test-data/create-data-profiles.md
+++ b/src/pages/docs/test-data/create-data-profiles.md
@@ -40,7 +40,8 @@ Test data profiles can significantly enhance the efficiency of your testing proc
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you begin, ensure you're familiar with concepts of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma.
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/address-function-type.md
+++ b/src/pages/docs/test-data/data-generators/address-function-type.md
@@ -83,9 +83,12 @@ Address functions generate various components of address data, such as street na
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/change-data-type-function-type.md
+++ b/src/pages/docs/test-data/data-generators/change-data-type-function-type.md
@@ -26,9 +26,12 @@ Change Data Type function allows you to transform an input value into a specifie
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/company-function-type.md
+++ b/src/pages/docs/test-data/data-generators/company-function-type.md
@@ -50,9 +50,12 @@ Company Functions are data generator tools that create realistic company-related
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/datefunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/datefunctions-function-type.md
@@ -56,9 +56,12 @@ DateFunctions enable you to generate and manipulate dates dynamically in various
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/default-list.md
+++ b/src/pages/docs/test-data/data-generators/default-list.md
@@ -57,7 +57,7 @@ contextual_links:
 
 ---
 
-Testsigma offers a variety of predefined data types, including text, number, date, email, phone number, and others. You can use these data types to create test data for various field types. Refer to [test data generator usage in test steps](https://testsigma.com/docs/test-data/types/data-generator/) to learn how to use the default test data generators in your test steps.
+Testsigma offers a variety of predefined data types, including text, number, date, email, phone number, and others. You can use these data types to create test data for various field types. For more information on test data generator usage in test steps, refer to the [documentation on test data generator usage in test steps](https://testsigma.com/docs/test-data/types/data-generator/) to learn how to use the default test data generators in your test steps.
 
 The following list categorises the available default test data generators.
 
@@ -284,7 +284,7 @@ The following list categorises the available default test data generators.
 ---
 
 [[info | NOTE:]]
-| - You can create your own Data Generator and customise the actions according to your preference. For more information, refer to [create test data generators using addons](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/)
-| - For some Data Generators, Regex is used to find a sequence of characters that specifies a search pattern in the text; if you're unfamiliar, refer to the [Regex guide - MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).
+| - You can create your own Data Generator and customise the actions according to your preference. For more information on creating test data generators using addons, refer to the [documentation on creating test data generators using addons](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/)
+| - For some Data Generators, Regex is used to find a sequence of characters that specifies a search pattern in the text; if you're unfamiliar, refer to the [documentation on regex guide - MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).
 
 ---

--- a/src/pages/docs/test-data/data-generators/domainfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/domainfunctions-function-type.md
@@ -26,9 +26,12 @@ Domain Functions design email addresses with specific domains. They create email
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/emailfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/emailfunctions-function-type.md
@@ -38,9 +38,12 @@ The EmailFunctions function type enables users to generate various types of emai
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/file-function-type.md
+++ b/src/pages/docs/test-data/data-generators/file-function-type.md
@@ -35,9 +35,12 @@ You can generate and manage various file-related data. This functionality is use
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/friends-function-type.md
+++ b/src/pages/docs/test-data/data-generators/friends-function-type.md
@@ -29,10 +29,12 @@ TestDataFromProfile functions enable users to retrieve specific test data from d
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
-
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 ---
 
 ## **Selecting Friends as a Function Type for Data Generator**

--- a/src/pages/docs/test-data/data-generators/idnumber-function-type.md
+++ b/src/pages/docs/test-data/data-generators/idnumber-function-type.md
@@ -38,9 +38,12 @@ You can generate and manage various file-related data. This functionality is use
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/internet-function-type.md
+++ b/src/pages/docs/test-data/data-generators/internet-function-type.md
@@ -56,9 +56,12 @@ The Internet Function Type and Function for Data Generators offer various functi
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/mailboxaliasfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/mailboxaliasfunctions-function-type.md
@@ -50,9 +50,13 @@ MailBoxAlias Functions enable dynamic interaction with email data in testing and
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [MailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> 4. [Documentation on creating mailboxfunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/mailboxfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/mailboxfunctions-function-type.md
@@ -56,9 +56,13 @@ MailBoxFunctions are specialized tools that facilitate efficient email managemen
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [MailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata 
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you proceed, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/). 
+> 4. [Documentation on adding MailBoxFunctions](https://testsigma.com/docs/test-data/types/mailbox/) for accessing and manipulating email content and metadata. 
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/name-function-type.md
+++ b/src/pages/docs/test-data/data-generators/name-function-type.md
@@ -50,9 +50,12 @@ The Name Function within data generators offers a variety of functions designed 
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/namefunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/namefunctions-function-type.md
@@ -26,9 +26,12 @@ NameFunctions Function Type in data generators helps you create usernames. It pr
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/number-function-type.md
+++ b/src/pages/docs/test-data/data-generators/number-function-type.md
@@ -47,9 +47,12 @@ The Number Function Type allows you to generate various types of random numbers.
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/numberfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/numberfunctions-function-type.md
@@ -26,9 +26,12 @@ NumberFunctions function type allows you to perform mathematical operations on n
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/phone-function-type.md
+++ b/src/pages/docs/test-data/data-generators/phone-function-type.md
@@ -29,9 +29,12 @@ Phone Number Function Type allows you to generate random, realistic phone number
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/phonenumberfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/phonenumberfunctions-function-type.md
@@ -26,9 +26,12 @@ Phone Number Function Type in data generators allows you to generate valid phone
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/random-string-function-type.md
+++ b/src/pages/docs/test-data/data-generators/random-string-function-type.md
@@ -26,9 +26,12 @@ NameFunctions Function Type in data generators helps you create usernames. It pr
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you proceed, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/). 
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/). 
+> 3. [Documentation on creating test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/random-text-function-type.md
+++ b/src/pages/docs/test-data/data-generators/random-text-function-type.md
@@ -26,9 +26,12 @@ RandomText Function Type allows you to generate random text strings of specified
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/stringfunctions-function-type.md
+++ b/src/pages/docs/test-data/data-generators/stringfunctions-function-type.md
@@ -29,9 +29,15 @@ StringFunctions allow you to manipulate and transform text strings effortlessly.
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [Parameters](https://testsigma.com/docs/test-data/types/parameter/), [Runtime](https://testsigma.com/docs/test-data/types/runtime/) and [Environments](https://testsigma.com/docs/test-data/types/environment/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> 4. [Documentation on adding parameters](https://testsigma.com/docs/test-data/types/parameter/).
+> 5. [Documentation on adding runtime](https://testsigma.com/docs/test-data/types/runtime/).
+> 6. [Documentation on creaing environments](https://testsigma.com/docs/test-data/types/environment/).
 
 ---
 

--- a/src/pages/docs/test-data/data-generators/testdatafromprofile-function-type.md
+++ b/src/pages/docs/test-data/data-generators/testdatafromprofile-function-type.md
@@ -29,9 +29,13 @@ TestDataFromProfile functions enable users to retrieve specific test data from d
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before utilising the different data generator functions, it's essential to understand basic concepts such as creating [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/) and [adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps. Additionally, familiarize yourself with [Test Data Profile](https://testsigma.com/docs/test-data/create-data-profiles/).
+> <p id="prerequisites">Prerequisites</p>
+> 
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-test-steps/overview/).
+> 3. [Documentation on adding data generators](https://testsigma.com/docs/test-data/types/data-generator/#add-data-generators-in-test-steps) in test steps.
+> 4. [Documentation on creating test data profile](https://testsigma.com/docs/test-data/create-data-profiles/).
 
 ---
 

--- a/src/pages/docs/test-data/types/data-generator.md
+++ b/src/pages/docs/test-data/types/data-generator.md
@@ -20,9 +20,15 @@ Testsigma allows you to automatically generate test data during test execution t
 
 ---
 
-#<p id="prerequisites">Prerequisites</p>
-
-Before using the Data Generators, you must understand specific concepts such as [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Create Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/) and [Test Data Types](https://testsigma.com/docs/test-data/types/overview/). Testsigma offers a collection of built-in test data generators in [Default Test Data Generators](https://testsigma.com/docs/test-data/data-generators/default-list/). Furthermore, you can [create custom test data generators](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/) using Java.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/). 
+> 3. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/).
+> 4. [Documentation on creating test data types](https://testsigma.com/docs/test-data/types/overview/). 
+> 5. [Documentation on managing default test data generators](https://testsigma.com/docs/test-data/data-generators/default-list/). 
+> 6. [Documentation on creating custom test data generators](https://testsigma.com/tutorials/addons/how-create-addons-test-data-generators/) using Java.
 
 ---
 

--- a/src/pages/docs/test-data/types/environment.md
+++ b/src/pages/docs/test-data/types/environment.md
@@ -41,10 +41,14 @@ In Testsigma, you can handle and use specific sets of test data linked to differ
 
 > <p id="prerequisites">Prerequisites</p>
 > 
-> - You should know how to create a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case) and [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/). 
-> - You should know how to create an [Environment](https://testsigma.com/docs/test-data/create-environment-data/).
-> - You should know how to create a [Test Plan](https://testsigma.com/docs/runs/test-plan-executions/#steps-to-create-and-execute-test-plan) and how to use them with [Test Data Types](https://testsigma.com/docs/test-data/types/overview/).
-> - You should know how to perform [Ad-Hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/#steps-to-perform-ad-hoc-runs-for-a-test-case).
+> 
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case).
+> 2. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
+> 3. [Documentation on creating environment](https://testsigma.com/docs/test-data/create-environment-data/).
+> 4. [Documentation on creating test plan](https://testsigma.com/docs/runs/test-plan-executions/#steps-to-create-and-execute-test-plan).
+> 5. [Documentation on creating test data types](https://testsigma.com/docs/test-data/types/overview/).
+> 6. [Documentation on performing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/#steps-to-perform-ad-hoc-runs-for-a-test-case).
 
 ---
 

--- a/src/pages/docs/test-data/types/mailbox.md
+++ b/src/pages/docs/test-data/types/mailbox.md
@@ -49,7 +49,12 @@ Testsigma provides a digital inbox called Mail Box to verify OTP accuracy, check
 
 > <p id="prerequisites">Prerequisites</p>
 > 
-> Before using Mailbox Test Data, ensure that you understand specific concepts such as creating a [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), managing [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and effectively using them with [Test Data Types](https://testsigma.com/docs/test-data/types/overview/) and [Data Generators](https://testsigma.com/docs/test-data/types/data-generator/). Additionally, familiarise yourself with [Regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) if necessary.
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case).
+> 2. [Documentation on managing test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
+> 3. [Documentation on creating test data types](https://testsigma.com/docs/test-data/types/overview/).
+> 4. [Documentation on data generators](https://testsigma.com/docs/test-data/types/data-generator/). 
+> 5. [Documentation on regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) if necessary.
 
 [[info | NOTE:]]
 | - You can enable Mail Box for your account by contacting **support@testsigma.com** or using the **instant chat** option.

--- a/src/pages/docs/test-data/types/overview.md
+++ b/src/pages/docs/test-data/types/overview.md
@@ -54,9 +54,12 @@ This documentation will explain the different test data types supported in Tests
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before using test data type, you must understand specific concepts such as creating [projects](https://testsigma.com/docs/projects/overview/), [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), and [test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on creting test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/).
 
 ---
 
@@ -82,7 +85,7 @@ Here is a quick GIF demonstrating the above workflow: ![Select Test Data Types](
 
 ## **Plain Text**
 
-You can use Plain Text as a test data type in Testsigma. It is perfect for entering static and fixed values in your test cases. This type is suitable for providing constant information like usernames, passwords, or text that doesn't change during testing. Raw Data, where the data is directly specified, frequently uses Plain Text test data for test steps. For more information, refer to [Plain Text - Raw Data](https://testsigma.com/docs/test-data/types/raw/).
+You can use Plain Text as a test data type in Testsigma. It is perfect for entering static and fixed values in your test cases. This type is suitable for providing constant information like usernames, passwords, or text that doesn't change during testing. Raw Data, where the data is directly specified, frequently uses Plain Text test data for test steps. For more information on plain text - raw data, refer to the [documentation on plain text - raw data](https://testsigma.com/docs/test-data/types/raw/).
 
 For example, at the start of the test case, we specify the URL to navigate as shown below:
 ![Plain Text data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/plaintext_testdata.png)
@@ -104,7 +107,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 ## **Parameter**
 
 - **Parameter Test Data** enables you to create a list of values for input during test execution and generate parameterised test cases to evaluate your application under different scenarios. This type of testing allows you to use parameters from your test data profile directly.
-- When selecting the parameter data type, you can choose the specific parameter required for your test case from a right-side panel with various available parameters. To perform data-driven testing, you can use Parameter Test Data. For more information, refer to the [Parameter Test Data Type](https://testsigma.com/docs/test-data/types/parameter/) and create [Test Data Profiles](https://testsigma.com/docs/test-data/create-data-profiles/) for [Data-driven Testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
+- When selecting the parameter data type, you can choose the specific parameter required for your test case from a right-side panel with various available parameters. To perform data-driven testing, you can use Parameter Test Data. For more information on parameter test data type, refer to the [documentation on parameter test data type](https://testsigma.com/docs/test-data/types/parameter/), [documentation on creating test data profiles](https://testsigma.com/docs/test-data/create-data-profiles/), and  [documentation on data-driven testing](https://testsigma.com/tutorials/test-cases/data-driven-testing/).
 - To use Parameter Test Data, use the **@ Parameter** type and replace the word "**Parameter**" with the specified parameter name. For example, replace test data with **@ user 1**, where **user 1** corresponds to the parameter name in the **Test Data Profile**. ![Parameter Testdata Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/parameter_testdatatypes.png)
 
 [[info | NOTE:]]
@@ -115,7 +118,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 ## **Runtime**
 
 - Use the **Store** keyword to store dynamic values, called **Runtime Variables**, that can change during a test. This keyword helps capture and reuse data within the same test Project, especially when dealing with values generated during the test.
-- You can use user-defined variables to define and manage Runtime data, and you don't need a separate interface for management. The execution of the test case is specific to the Runtime Test Data. Refer to the [Runtime Test Data](https://testsigma.com/docs/test-data/types/runtime/) for more information. ![Runtime Test Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/runtime_testdata_type.png)
+- You can use user-defined variables to define and manage Runtime data, and you don't need a separate interface for management. The execution of the test case is specific to the Runtime Test Data. For more information on runtime test data, refer to the [documentation on runtime test data](https://testsigma.com/docs/test-data/types/runtime/). ![Runtime Test Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/runtime_testdata_type.png)
 - Use a runtime data parameter to check a web page's title before and after a page reload. First, use a command to store the title in a runtime data parameter called "**Travel**". Then, verify the page title after reloading the page using the stored parameter with the statement You should see the page title as **$ Travel**.
 
 ---
@@ -124,7 +127,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 
 - Manage Environment Test Data Type on the Environments page with a limited scope to a project. The Environment Test Data Type contains environment-related information like URLs, API endpoints, and database connection details. You must configure test cases to work in various environments (e.g., development, staging, production).
 
-- You can use the *** Environment** type and substitute the parameter's name for "**Environment**" to use Testsigma's most versatile Test Data Type, the Environment Parameter. Refer to the [Environment](https://testsigma.com/docs/test-data/types/environment/) for more information. ![Environment Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/environment_testdata_type.png)
+- You can use the *** Environment** type and substitute the parameter's name for "**Environment**" to use Testsigma's most versatile Test Data Type, the Environment Parameter. For more information on environment, refer to the [documentation on environment](https://testsigma.com/docs/test-data/types/environment/). ![Environment Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/environment_testdata_type.png)
 
 [[info | EXAMPLE:]]
 | During executions, you can access separate Environment sets to store URLs and login details for environments like Production, Testing, Development, UAT, or Staging servers.
@@ -133,7 +136,7 @@ In this instance, we use Plain Text test data by directly providing the test dat
 
 ## **Random**
 
-Random Test Data Type generates random data such as numbers, email addresses, and passwords to add variety to your tests and create diverse test scenarios with unpredictable data. You can use the format **~ Random** and replace **~ Random** with an integer value from 1 to 256 to generate random values for Test Case execution. During Test Case Execution, you can specify the length of the alphanumeric character you want to receive by providing an integer value. Refer to the [Random Test Data](https://testsigma.com/docs/test-data/types/random/) for more information. ![Random Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/random_testdata_type.png)
+Random Test Data Type generates random data such as numbers, email addresses, and passwords to add variety to your tests and create diverse test scenarios with unpredictable data. You can use the format **~ Random** and replace **~ Random** with an integer value from 1 to 256 to generate random values for Test Case execution. During Test Case Execution, you can specify the length of the alphanumeric character you want to receive by providing an integer value. For more information on random test data, refer to the [documentation on random test data](https://testsigma.com/docs/test-data/types/random/). ![Random Test data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/random_testdata_type.png)
 
 [[info | EXAMPLE:]]
 | When you use **~|25|** in your test data, you will replace it with a **25**-character-long alphanumeric string during execution. Testsigma provides a random alphanumeric string of **N** characters when you include **~|N|** in a Test Step.
@@ -142,24 +145,24 @@ Random Test Data Type generates random data such as numbers, email addresses, an
 
 ## **Data Generator**
 
-Data Generator test data type generates realistic and structured data for testing purposes, such as names, addresses, and emails. You can obtain dynamic data by using the **Default Test Data Generator Functions**. To use them, you must substitute "**Data Generator**" with the specific name required in the **! Data Generator** format. Refer to the [Data Generator](https://testsigma.com/docs/test-data/types/data-generator/) for more information. ![Data Generator Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/datagenerator_datatype.png)
+Data Generator test data type generates realistic and structured data for testing purposes, such as names, addresses, and emails. You can obtain dynamic data by using the **Default Test Data Generator Functions**. To use them, you must substitute "**Data Generator**" with the specific name required in the **! Data Generator** format. For more information on data generator, refer to the [documentation on data generator](https://testsigma.com/docs/test-data/types/data-generator/). ![Data Generator Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/datagenerator_datatype.png)
 
 ---
 
 ## **Phone Number**
 
-Phone Number test data type allows you to create random or predefined phone numbers for testing SMS or phone number validation features. If you need a valid phone number to receive SMS codes for scenarios like two-factor authentication testing, Testsigma provides a test phone number that you can use as test data in your test steps. Refer to the [Phone Number](https://testsigma.com/docs/test-data/types/phone-number/) and [2-step Authentication](https://testsigma.com/tutorials/advanced/sms-based-two-factor-authentication-2fa/) for more information. ![Phone Number Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/phonenumber_testdatatype.png)
+Phone Number test data type allows you to create random or predefined phone numbers for testing SMS or phone number validation features. If you need a valid phone number to receive SMS codes for scenarios like two-factor authentication testing, Testsigma provides a test phone number that you can use as test data in your test steps. For more information on phone number and 2-step authentication, refer to the [documentation on phone number](https://testsigma.com/docs/test-data/types/phone-number/) and [documentation on 2-step authentication](https://testsigma.com/tutorials/advanced/sms-based-two-factor-authentication-2fa/). ![Phone Number Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/phonenumber_testdatatype.png)
 
 ---
 
 ## **Mail Box**
 
-Mailbox test data type generates email addresses and mailbox data for testing email-related functions, particularly for workflows involving OTPs or activation links. Testsigma enables you to use provisioned mailbox email addresses to input test data. Refer to the [Mail Box](https://testsigma.com/docs/test-data/types/mailbox/) for more information. ![Mail Box Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/mailbox_testdatatype.png)
+Mailbox test data type generates email addresses and mailbox data for testing email-related functions, particularly for workflows involving OTPs or activation links. Testsigma enables you to use provisioned mailbox email addresses to input test data. For more information on mail box, refer to the [documentation on mail box](https://testsigma.com/docs/test-data/types/mailbox/). ![Mail Box Data Type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/mailbox_testdatatype.png)
 
 ---
 
 ## **Upload**
 
-Upload test data type enables you to easily upload files and applications to your tests using NLP, streamlining the process of adding attachments to your test cases. Refer to the [Upload Files](https://testsigma.com/docs/uploads/upload-files/) & [Apps](https://testsigma.com/docs/uploads/upload-apps/) for more information. ![Upload data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/upload_testdata_type.png)
+Upload test data type enables you to easily upload files and applications to your tests using NLP, streamlining the process of adding attachments to your test cases. For more information on uploading files and apps, refer to the [documentation on uploading files](https://testsigma.com/docs/uploads/upload-files/) & [documentation on apps](https://testsigma.com/docs/uploads/upload-apps/). ![Upload data type](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/upload_testdata_type.png)
 
 ---

--- a/src/pages/docs/test-data/types/runtime.md
+++ b/src/pages/docs/test-data/types/runtime.md
@@ -25,9 +25,15 @@ contextual_links:
 In Testsigma, Runtime Test Data allows you to save data gathered while running a Test Case. For example, you can utilise the Runtime Test Data Type to copy data from one page and confirm its presence on another page. The Runtime Test Data Type in Testsigma lets you dynamically store and use data during the test. You can keep this data as a runtime variable, making automated tests more flexible and adaptable.
 
 ---
-#<p id="prerequisites">Prerequisites</p>
-
-Before using Runtime Test Data, ensure you understand specific concepts such as creating a [Project](https://testsigma.com/docs/projects/overview/), [Test Case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case), and [Elements](https://testsigma.com/docs/elements/overview/), managing [Test Steps](https://testsigma.com/docs/test-cases/step-types/natural-language/), and effectively using them with [Test Data Types](https://testsigma.com/docs/test-data/types/overview/).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating project](https://testsigma.com/docs/projects/overview/).
+> 3. [Documentation on creating test case](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#creating-a-test-case).
+> 4. [Documentation on creating elements](https://testsigma.com/docs/elements/overview/). 
+> 5. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/step-types/natural-language/).
+> 6. [Documentation on creating test data types](https://testsigma.com/docs/test-data/types/overview/).
 
 ---
 

--- a/src/pages/docs/test-plans/after-test.md
+++ b/src/pages/docs/test-plans/after-test.md
@@ -25,7 +25,7 @@ contextual_links:
 
 AfterTest in Testsigma lets you create a block of steps after the test case as well as add a step group to execute irrespective of the result of the test case. Both test case and after test blocks execute independently. This article will discuss how to enable and use after test in test cases and step groups. 
 
-*For more information on Test Cases, refer to [test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
+*For more information on test cases, refer to [ documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).*
 
 
 ---

--- a/src/pages/docs/test-plans/cross-browser-testing.md
+++ b/src/pages/docs/test-plans/cross-browser-testing.md
@@ -27,7 +27,10 @@ Cross Browser Testing is testing web applications across multiple browsers to en
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to: 
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-plans/distributed-testing.md
+++ b/src/pages/docs/test-plans/distributed-testing.md
@@ -34,7 +34,10 @@ Distributed testing is achieved in Testsigma by splitting up test plan execution
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to: 
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-plans/email-configuration.md
+++ b/src/pages/docs/test-plans/email-configuration.md
@@ -26,7 +26,8 @@ Setting up email notifications for test plans in Testsigma helps you stay inform
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concept of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/test-plans/headless-testing.md
+++ b/src/pages/docs/test-plans/headless-testing.md
@@ -37,7 +37,12 @@ This guide will explain how to do headless browser testing in Testsigma. It will
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before using the Headless browser testing feature, you should understand the concepts of [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Plans](https://testsigma.com/docs/test-management/test-plans/overview/), [Ad-hoc Runs](https://testsigma.com/docs/runs/adhoc-runs/), and [Test Machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/) in Testsigma.
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 3. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 4. [Documentation on managing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/).
+> 5. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 [[info | NOTE:]]
 | Headless testing can test web applications

--- a/src/pages/docs/test-plans/manage-test-machines.md
+++ b/src/pages/docs/test-plans/manage-test-machines.md
@@ -32,8 +32,9 @@ While creating a test plan, you must add at least one test machine to a test sui
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/) and [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/).
-
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suite](https://testsigma.com/docs/test-management/test-suites/overview/). 
 
 ---
 

--- a/src/pages/docs/test-plans/manage-test-suites.md
+++ b/src/pages/docs/test-plans/manage-test-suites.md
@@ -25,12 +25,12 @@ While creating a test plan, you need to add at least one test suite to the test 
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
-
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suite](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-plans/overview.md
+++ b/src/pages/docs/test-plans/overview.md
@@ -34,7 +34,10 @@ In Testsigma, the Test Plan helps plan and organise software testing. The Test P
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before using a Test Plan, you must understand specific concepts, such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and [Test Suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/).
+> 2. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 3. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
 
 ---
 
@@ -57,10 +60,10 @@ In Testsigma, the Test Plan helps plan and organise software testing. The Test P
     - **Labels**: You can label the Test Plan. Labels make it easier to manage multiple Test Plans, as they help with sorting and grouping.
     - **Test Plan Type**: Select either the test plan type: **Cross Browser Testing** (Use single/ multiple browsers to test all the test suites; for more information, refer to [Cross Browser Testing](https://testsigma.com/docs/test-management/test-plans/cross-browser-testing/)) or **Custom Test Plan** (Manually add test machine profiles to individual test suites).
 3. In the **Add Test Suites & Link Machine Profiles** tab, provide the following details and then click **Continue**:
-    - Click **Add Test Suites** to include test suites in the test plan (for more information, refer to [Manage Test Suites in Test Plan](https://testsigma.com/docs/test-management/test-plans/manage-test-suites/)).
+    - Click **Add Test Suites** to include test suites in the test plan (for more information on managing test suites in a test plan, refer to the [documentation on Manage Test Suites in Test Plan](https://testsigma.com/docs/test-management/test-plans/manage-test-suites/)).
     - Next, click the **Test Machine** icon to add machine profiles to the test plan. An overlay will appear, and you can select a pre-defined machine or create a new test machine. Once you have selected, click **Save Selection** (for more information, refer to [Manage Test Machines in Test Plan](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/)).
 4. In the **Test Plan Settings** tab, provide the following details, and click **Create**:
-    - **Send Notification**: Enable the toggle for Send Notification and specify when to receive the notifications (for example, select to receive notifications when your test plans are **Passed**, **Failed**, **Not Executed**, **Queued**, **Stopped**, or **Running**. You can enter the emails or check the box to **Add my email** for receiving notifications through email. Messages can also be sent to collaboration tools like Google Chat, Slack, or MS Teams.
+    - **Send Notification**: Enable the toggle for Send Notification and specify when to receive the notifications (for example, select to receive notifications when your test plans are **Passed**, **Failed**, **Not Executed**, **Queued**, **Stopped**, or **Running**.) You can enter the emails or check the box to **Add my email** for receiving notifications through email. Messages can also be sent to collaboration tools like Google Chat, Slack, or MS Teams.
     - **Additional Settings**: Provide the following details under additional settings:
         - **Environment**: Select the test environment.
         - **Screenshot Capture**: Select when the screenshots need to be taken, for **None**, **All Steps** or **Failed Steps alone**.

--- a/src/pages/docs/test-plans/partial-test-plan-run-via-api.md
+++ b/src/pages/docs/test-plans/partial-test-plan-run-via-api.md
@@ -10,6 +10,9 @@ contextual_links:
 - type: section
   name: "Contents"
 - type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
   name: "Configure Partial Test Plan Run"
   url: "#configure-partial-test-plan-run"
 - type: link
@@ -28,10 +31,14 @@ contextual_links:
 
 Performing a partial run in a test plan via an API call in Testsigma enables you to execute specific test suites and apply filters programmatically, providing flexibility and automation in your testing workflow. This documentation will guide you through configuring a partial test plan run, executing it via an API call, and scheduling the partial run for future execution.
 
-Ensure you fulfil the following prerequisites before proceeding with the steps:
-- Create a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/) 
-- Obtain an [API key for Authorization](https://testsigma.com/docs/configuration/api-keys/) 
-- [Get Test Plan ID](https://testsigma.com/docs/continuous-integration/get-test-plan-details/)
+---
+
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/). 
+> 2. [Documentation on creating API key for authorization](https://testsigma.com/docs/configuration/api-keys/). 
+> 3. [Documentation on getting test plan ID](https://testsigma.com/docs/continuous-integration/get-test-plan-details/).
 
 ---
 

--- a/src/pages/docs/test-plans/run-tests-in-parallel.md
+++ b/src/pages/docs/test-plans/run-tests-in-parallel.md
@@ -29,7 +29,10 @@ Executing tests in parallel significantly improves testing efficiency by reducin
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you proceed, ensure you understand the concepts of creating a [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/), [Test Suite](https://testsigma.com/docs/test-management/test-suites/overview/), and [Test Machine](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
+> 2. [Documentation on creating test suites](https://testsigma.com/docs/test-management/test-suites/overview/).
+> 3. [Documentation on creating test machines](https://testsigma.com/docs/test-management/test-plans/manage-test-machines/).
 
 ---
 

--- a/src/pages/docs/test-plans/schedule-plans.md
+++ b/src/pages/docs/test-plans/schedule-plans.md
@@ -34,7 +34,8 @@ In Testsigma, you can schedule your test plans to automate their execution and m
 
 > <p id="prerequisites">Prerequisites</p>
 >
-> Before you schedule a test plan in Testsigma, you must understand the concepts of creating the [Test Plan](https://testsigma.com/docs/test-management/test-plans/overview/).
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test plans](https://testsigma.com/docs/test-management/test-plans/overview/).
 
 ---
 

--- a/src/pages/docs/test-suites/dynamic-test-suites.md
+++ b/src/pages/docs/test-suites/dynamic-test-suites.md
@@ -37,9 +37,10 @@ Dynamic Test Suites in Testsigma provide an efficient way to streamline test exe
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before you begin, ensure that you are familiar with the concept of [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in Testsigma. 
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
 
 ---
 

--- a/src/pages/docs/test-suites/overview.md
+++ b/src/pages/docs/test-suites/overview.md
@@ -32,9 +32,11 @@ Organise your test cases into test suites based on common functionalities or sce
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Ensure that you create [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) in the Same [Project](https://testsigma.com/docs/projects/overview/) before you can manage test suites in Testsigma.
+> <p id="prerequisites">Prerequisites</p>
+> 
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/).
+> 2. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/). 
 
 ---
 

--- a/src/pages/docs/uploads/upload-apps.md
+++ b/src/pages/docs/uploads/upload-apps.md
@@ -27,9 +27,12 @@ Upload your Android and iOS apps to the Testsigma Cloud to quickly develop and e
 This guide will demonstrate how to do this and automate your mobile app testing, ensuring the quality and reliability of your applications.
 
 ---
-#<p id="prerequisites">Prerequisites</p>
-
-Before uploading the Android and iOS applications, you must understand specific concepts, such as creating [Projects](https://testsigma.com/docs/projects/overview/) and [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/) and uploading the **Android** app as a **.apk** file and the **iOS** app as a **.ipa** file for testing.
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/). 
+> 3. Uploadied the **Android** app as a **.apk** file and the **iOS** app as a **.ipa** file for testing.
 
 ---
 

--- a/src/pages/docs/visual-testing/configure-test-steps.md
+++ b/src/pages/docs/visual-testing/configure-test-steps.md
@@ -41,9 +41,15 @@ Testsigma allows you to check your app's appearance during tests using its Visua
 
 ---
 
-<p id="prerequisites">Prerequisites</p>
-
-Before using Visual Testing, you must understand specific concepts such as creating [Projects](https://testsigma.com/docs/projects/overview/), [Test Cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/), [Test Steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/), utilising [Test Step Options](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-settings/), [Ad-hoc Run](https://testsigma.com/docs/runs/adhoc-runs/), and [Test Case - Advanced Options](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#test-case----advanced-options).
+> <p id="prerequisites">Prerequisites</p>
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on creating test cases](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#create-test-case).
+> 2. [Documentation on creating projects](https://testsigma.com/docs/projects/overview/). 
+> 3. [Documentation on creating test steps](https://testsigma.com/docs/test-cases/create-steps-nl/overview/). 
+> 4. [Documentation on utilising test step options](https://testsigma.com/docs/test-cases/create-test-steps/actions-and-options-manual/step-settings/).
+> 5. [Documentation on managing Ad-Hoc runs](https://testsigma.com/docs/runs/adhoc-runs/).
+> 6. [Documentation on managing test case - advanced options](https://testsigma.com/docs/test-cases/manage/add-edit-delete/#test-case----advanced-options).
 
 ---
 
@@ -73,7 +79,7 @@ In Testsigma, you can save time and reduce redundant efforts by selecting multip
 
 When you conduct visual testing using Testsigma, you should compare the **current image** (reference image) with the original image (baseline image) and ensure that the reference image matches the baseline image. You should update the baseline image whenever you apply changes to the UI using the following steps:
 
-1. You have two options to enable visual testing in your test steps: [Enable Visual Testing in Test Step](https://testsigma.com/docs/visual-testing/configure-test-steps/#enable-visual-testing-in-test-steps) or [Bulk Action for Visual Testing Steps](https://testsigma.com/docs/visual-testing/configure-test-steps/#bulk-action-for-visual-testing-steps). **Run** the test case after enabling it in Test Step.
+1. You have two options to enable visual testing in your test steps: [Documentation on enabling visual testing in test steps](https://testsigma.com/docs/visual-testing/configure-test-steps/#enable-visual-testing-in-test-steps) or [Documentation on bulking action for visual testing steps](https://testsigma.com/docs/visual-testing/configure-test-steps/#bulk-action-for-visual-testing-steps). **Run** the test case after enabling it in Test Step.
 2. **Re-Run** the test case to enable visual testing and see any visual differences. ![Rerun Test Case](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/reruntestcase_visualtesting.png)
 3. After executing a test case for visual testing, the **Test Case Result** page will display a **green camera** icon on steps with **no visual differences** between the reference and baseline images and a **red camera** icon where there are **visual differences**.
 4. Click on the **camera** icon to open the **Visual Difference** overlay screen. Then, go to the top right of the page and **check** the box **Mark as base image** as **Current Image**. This action will update your base image to match your current reference image.
@@ -92,7 +98,7 @@ When you conduct visual testing using Testsigma, you should compare the **curren
 
 ## **Perform Visual Testing in Test Case**
 
-1. Follow the steps in the above section to Enable Visual Testing in Test Steps using [Test Step Options](https://testsigma.com/docs/visual-testing/configure-test-steps/#enable-visual-testing-in-test-steps) or [Update Settings](https://testsigma.com/docs/visual-testing/configure-test-steps/#bulk-action-for-visual-testing-steps). [Mark the Baseline Image](https://testsigma.com/docs/visual-testing/configure-test-steps/#bulk-action-for-visual-testing-steps) and run the test case to identify visual differences in the UI.
+1. Follow the steps in the above section to Enable Visual Testing in Test Steps using [documentation on utilising test step options](https://testsigma.com/docs/visual-testing/configure-test-steps/#enable-visual-testing-in-test-steps) or [documentation on updating settings](https://testsigma.com/docs/visual-testing/configure-test-steps/#bulk-action-for-visual-testing-steps). Refer to the [documentation on marking the baseline image](https://testsigma.com/docs/visual-testing/configure-test-steps/#bulk-action-for-visual-testing-steps) and run the test case to identify visual differences in the UI.
 2. Click on **Test Case Settings** in the right-side navbar and enable the **Fail Test Case if Visual Testing Fails** toggle to automatically mark a test case as failed if it detects visual differences during execution. ![Perform Visual Testing](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/perform_visualtesting.gif)
 
 ---

--- a/src/pages/docs/visual-testing/visual-testing-with-figma-designs.md
+++ b/src/pages/docs/visual-testing/visual-testing-with-figma-designs.md
@@ -31,8 +31,9 @@ You can now compare test execution screenshots with original design files in Fig
 ---
 
 > <p id="prerequisites">Prerequisites</p>
-> 
-> Before you begin, make sure you know how to configure test steps for visual testing in Testsigma. For more information, see [Visual Testing](https://testsigma.com/docs/visual-testing/configure-test-steps/).
+>
+> Before you begin, ensure that you have referred to:
+> 1. [Documentation on configuring visual testing](https://testsigma.com/docs/visual-testing/configure-test-steps/).
 
 ---
 


### PR DESCRIPTION
Updated SEO keywords internal linking in Docs as per the ticket: https://testsigma.atlassian.net/browse/DOC-349

<img width="1725" height="1034" alt="image" src="https://github.com/user-attachments/assets/5cf13ffc-7db2-4987-bd7f-ac5a5337191c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized “Prerequisites” across many pages to blockquoted, checklist-style references to specific guides.
  - Updated link texts and anchors for clarity (e.g., direct “create test case” anchors, precise integration docs).
  - Refreshed Best Practices, Test Data Types/Generators, and Test Suites/Test Plans docs with clearer cross-references.
  - Enhanced GenAI and Copilot pages with explicit enablement steps and prerequisites.
  - Improved navigation with anchors/Contents entries on select pages.
  - Expanded Visual Testing docs with detailed Visual Difference overlay options (highlight, hide, region ignore, merge, zoom).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->