### PR TITLE
Added Command-Line Arguments & Usage Guide

### DIFF
--- a/src/left-nav-title.json
+++ b/src/left-nav-title.json
@@ -740,5 +740,6 @@
   "codemagic-ci" : {"/docs/continuous-integration/codemagic-ci/": "Codemagic CI/CD"},
   "google-cloud-build-ci" : {"/docs/continuous-integration/google-cloud-build-ci/": "Google Cloud Build CI/CD"},
   "jira-server" : {"/docs/atto/generative-ai/integrations/jira-server/": "Jira Server"},
-  "audit-logs": {"/docs/activity-monitoring/audit-logs/": "Audit Logs" }
+  "audit-logs": {"/docs/activity-monitoring/audit-logs/": "Audit Logs" },
+  "command-line-arguments": {"/docs/agent/command-line-arguments/": "Arguments Usage Details" }
 }

--- a/src/pages/docs/agent/command-line-arguments.md
+++ b/src/pages/docs/agent/command-line-arguments.md
@@ -1,0 +1,372 @@
+---
+title: "Command-Line Arguments & Usage Guide"
+metadesc: "Customize the behavior of the Testsigma Agent by passing command-line arguments when starting it from the installation directory in Testsigma"
+noindex: false
+order: 11.4
+page_id: "using-command-line-arguments"
+warning: false
+contextual_links:
+- type: section
+  name: "Contents"
+- type: link
+  name: "Prerequisites"
+  url: "#prerequisites"
+- type: link
+  name: "Steps to Trigger Tests on Local Devices"
+  url: "#steps-to-trigger-tests-on-local-devices"
+---
+
+---
+
+You can customize the behavior of the Testsigma Agent by passing command-line arguments when starting it from the installation directory. These arguments let you configure registration, logging, memory usage, browsers, proxies, and other advanced settings. This article discusses the available arguments, their purpose, and how to use them.
+
+---
+
+## **Arguments and Usage Details**
+
+### Argument: **`--TS_ACTIVATION_KEY`**
+
+Use this argument to create an agent and activate it later. 
+
+1. Create an agent and select **Activate Later**.
+
+2. From the Agent Details page, copy the activation key.
+   ```bash
+   --TS_ACTIVATION_KEY=<KEY>
+   ```
+
+3. Open a terminal and run the following command from the agent installation directory:
+   ```bash
+   ./TestsigmaAgent --TS_ACTIVATION_KEY=<KEY>
+   ```
+4. The agent activates.
+
+---
+
+### Arguments: **`--TS_AUTO_REGISTRATION_KEY`** & **`--TS_AUTO_REGISTRATION_TITLE`**<br>
+
+Use these arguments to automatically register an agent with a title.
+
+1. From the **Dashboard**, go to **Settings > API Keys**.
+
+2. Click **Create API Key**, and copy the generated key.
+
+3. Open a terminal and run the following command from the agent installation directory:
+   
+   ```bash
+   ./TestsigmaAgent --TS_AUTO_REGISTRATION_KEY=<KEY> --TS_AUTO_REGISTRATION_TITLE=<agent-title>
+   ```
+
+4. The agent registers and activates with the specified title.
+
+---
+
+### Arguments: **`--TS_AUTO_REGISTRATION_HTTPS_PORT`** & **`--TS_AUTO_REGISTRATION_HTTP_PORT`**
+
+Use these arguments to specify the HTTPS and HTTP ports for auto-registering the agent.
+
+1. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent \
+   --TS_AUTO_REGISTRATION_KEY=<KEY> \
+   --TS_AUTO_REGISTRATION_TITLE=<unique-agent-title> \
+   --TS_AUTO_REGISTRATION_HTTPS_PORT=<port> \
+   --TS_AUTO_REGISTRATION_HTTP_PORT=<port>
+   ```
+
+2. The agent registers using the specified ports.
+
+---
+
+### Argument: **`--TS_ADDITIONAL_JVM_ARGS`**
+Use this argument to pass additional Java Virtual Machine arguments to the agent. This is useful for advanced tuning, debugging, or custom runtime configurations.
+
+1. Identify the JVM arguments you want to pass.
+   
+   **Example**: 
+   ```bash   
+   -Dlogging.file.name=/var/log/testsigma/agent.log
+   ```
+
+2. Open a terminal and run the following command from the agent installation directory:
+   
+   ```bash
+   ./TestsigmaAgent --TS_ADDITIONAL_JVM_ARGS="-Dlogging.file.name=/var/log/testsigma/agent.log"
+   ```
+3. The agent starts with the specified JVM arguments.
+
+[[info | **NOTE**:]]
+| - Wrap multiple JVM arguments in quotes. <br>
+|   **Example**: 
+|    ```bash
+|    ./TestsigmaAgent --TS_ADDITIONAL_JVM_ARGS="-Dlogging.file.name=/var/log/testsigma/agent.log -Dlogging.level=debug"
+|      ```
+| - Use this option to add custom properties that are not covered by predefined agent arguments.
+
+---
+
+### Argument: **`--TS_AGENT_JAR_PATH`**
+
+Use this argument to specify the file system path to the agent.jar file. This is useful when the JAR is maintained in a custom directory. 
+
+1. Locate the `agent.jar` file on your system.
+
+2. Open a terminal and run the following command from the agent installation directory:
+   
+   ```bash
+   ./TestsigmaAgent --TS_AGENT_JAR_PATH=<path-to-jar-file>
+   ```
+
+3. The agent runs using the JAR from the specified path.
+
+---
+
+###  Arguments: **`--TS_CHROME_PATH`**, **`--TS_EDGE_PATH`**, & **`--TS_FIREFOX_PATH`**
+
+Use these arguments to specify the file system path for a browser executable. This ensures that the agent runs tests on the specified browser version.
+
+1. Install the required browser version on your system.
+
+2. Identify the full path to the browser executable.
+
+3. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_CHROME_PATH=<path-to-chrome> \
+   --TS_EDGE_PATH=<path-to-edge> \
+   --TS_FIREFOX_PATH=<path-to-firefox>
+   --TS_IE_PATH=<path-to-internet-explorer>
+   ```
+
+4. The agent runs tests using the specified browser versions.
+
+---
+
+### Argument: **`--TS_DATA_DIR`**
+
+Use this argument to specify the file system path where the agent stores its data.
+
+1. Identify the directory where you want the agent to store its data.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_DATA_DIR=<path-to-data-directory>
+   ```
+
+3. The agent stores all data in the specified directory.
+
+---
+
+### Argument: **`--TS_ENABLE_GC_LOG`**
+
+Use this argument to enable garbage collection logging which helps in diagnosing memory usage issues and performance.
+
+1. Decide whether to enable GC logging.
+   - **To enable**: true
+   - **To disable**: false (default)
+
+2. Open a terminal and run the following command from the agent installation directory:
+   
+   ```bash
+   ./TestsigmaAgent --TS_ENABLE_GC_LOG=true
+   ```
+
+3. The agent starts with GC logging enabled.
+
+---
+
+### Argument: **`--TS_ENABLE_HEAP_DUMP`**
+
+Use this argument to enable heap dump generation if the agent process crashes.
+
+1. Decide whether to enable heap dump generation.
+   **To enable**: true
+   **To disable**: false (default)
+
+2. Open a terminal and run the following command from the agent installation directory:
+   
+   ```bash
+   ./TestsigmaAgent --TS_ENABLE_HEAP_DUMP=true
+   ```
+
+3. If the agent process crashes, a heap dump file is created in the agent’s working directory.
+
+---
+
+### Argument: **`--TS_DELEGATE_SSL_VALIDATION`**
+
+Use this argument to delegate SSL certificate validation to the operating system.
+
+1. Decide whether to enable or disable system-level SSL validation.
+   - **To enable**: true
+   - **To disable**: false (default)
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_DELEGATE_SSL_VALIDATION=true
+   ```
+
+3. The agent starts using the system certificate store for SSL validation.
+
+---
+
+### Argument: **`--TS_IS_HEADLESS`**
+
+Use this argument to run the agent in headless mode. In headless mode, the browsers controlled by the agent run without a visible user interface.
+
+1. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_IS_HEADLESS=true
+   ```
+
+2. The agent starts in headless mode & executes all tests without opening browser windows.
+
+---
+
+### Argument: **`--TS_IS_MOBILE_DISABLED`**
+
+Use this argument to disable all mobile testing capabilities on the agent. Disabling mobile support reduces resource consumption and helps tests run faster.
+
+1. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_IS_MOBILE_DISABLED=true
+   ```
+
+2. The agent starts with mobile testing disabled.
+
+---
+
+### Argument: **`--TS_JAVA_HOME`**
+
+Use this argument to specify the system path to the Java Runtime Environment that the agent should use.
+
+1. Identify the system path of the required Java installation.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_JAVA_HOME=<path-to-java>
+   ```
+
+3. The agent starts using the specified Java runtime.
+
+---
+
+### Argument: **`--TS_LOGGING_LEVEL`**
+
+Use this argument to specify the logging level for the agent. The logging level controls the amount of detail written to the agent logs.
+
+**Supported Values**
+   - **DEBUG**: Detailed diagnostic information for troubleshooting.
+   - **INFO**: General operational messages (default).
+   - **WARN**: Warnings about potential issues.
+   - **ERROR**: Error messages only.
+
+**Steps**
+
+1. Decide the logging level you want to set.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_LOGGING_LEVEL=DEBUG
+   ```
+
+3. The agent starts with the specified logging level.
+
+---
+
+### Arguments: **`--TS_MAX_MEMORY`** & **`--TS_MIN_MEMORY`**
+
+Use these arguments to configure Java heap memory allocation for the agent.
+
+1. Decide the memory values you want to allocate.
+   - Use **m** to specify megabytes (for example, 1024m).
+   - Use **g** to specify gigabytes (for example, 4g).
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_MIN_MEMORY=1024m --TS_MAX_MEMORY=4096m
+   ```
+3. The agent starts with the specified memory settings.
+
+---
+
+### Argument: **`--TS_NON_PROXY_HOSTS`**
+
+Use this argument to specify a comma-separated list of hosts that should bypass proxy settings.
+
+1. Identify the hosts that should bypass the proxy.
+
+   **Example**: `localhost`, `127.0.0.1`, `my-internal-server`.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_NON_PROXY_HOSTS="localhost,127.0.0.1,my-internal-server"
+   ```
+
+3. The agent connects directly to the specified hosts.
+
+---
+
+### Argument: **`--TS_ROOT_DIR`**
+
+Use this argument to specify the file system path where the agent is installed.
+
+1. Identify the directory where the agent is installed or should be installed.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_ROOT_DIR=<path-to-directory>
+   ```
+
+3. The agent starts using the specified root directory.
+
+---
+
+### Argument: **`--TS_USE_SYSTEM_PROXY`**
+
+Use this argument to configure the agent to use the system proxy settings for all network calls.
+
+1. Ensure your system proxy settings are correctly configured.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_USE_SYSTEM_PROXY=true
+   ```
+
+3. The agent starts using the system-configured proxy settings.
+
+---
+
+### Argument: **`--TS_TRUST_STORE_TYPE`**
+
+Use this argument to specify the type of trust store for SSL certificate validation.
+
+**Supported Values**
+   - **JKS**: Java KeyStore (default).
+   - **PKCS12**: Public Key Cryptography Standard #12.
+   - **WINDOWS-ROOT**: Uses the Windows system certificate store.
+
+**Steps**
+
+1. Decide which trust store type your environment requires.
+
+2. Open a terminal and run the following command from the agent installation directory:
+
+   ```bash
+   ./TestsigmaAgent --TS_TRUST_STORE_TYPE=WINDOWS-ROOT
+   ```
+
+3. The agent starts using the specified trust store type.
+
+---

--- a/src/pages/docs/agent/connect-android-local-devices.md
+++ b/src/pages/docs/agent/connect-android-local-devices.md
@@ -1,7 +1,7 @@
 ---
 title: "Setting up Android Local Devices"
-order: 11.4
-page_id: "Setup: Android Local Devices"
+order: 11.5
+page_id: "setup-android-local-devices"
 metadesc: "Run tests on your local Android devices in addition to Testsigma Cloud machines/devices. Learn how to setup Android Local Devices in Testsigma application."
 noindex: false
 search_keyword: ""

--- a/src/pages/docs/agent/connect-ios-local-devices.md
+++ b/src/pages/docs/agent/connect-ios-local-devices.md
@@ -1,7 +1,7 @@
 ---
 title: "Setting up iOS Local Devices"
 order: 11.5
-page_id: "Setup: iOS Local Devices"
+page_id: "setup-ios-local-devices"
 metadesc: "Run tests on your local iOS devices in addition to Testsigma Cloud machines/devices. Learn how to setup iOS Local Devices in Testsigma application."
 noindex: false
 search_keyword: ""

--- a/src/pages/docs/agent/faqs.md
+++ b/src/pages/docs/agent/faqs.md
@@ -2,8 +2,8 @@
 title: "Testsigma Agent - FAQs"
 metadesc: "Frequently Asked Questions about the Testsigma Agent."
 noindex: false
-order: 11.93
-page_id: "Testsigma Agent - FAQ"
+order: 11.84
+page_id: "testsigma-agent-faqs"
 search_keyword: ""
 warning: false
 contextual_links:

--- a/src/pages/docs/agent/force-delete.md
+++ b/src/pages/docs/agent/force-delete.md
@@ -2,8 +2,8 @@
 title: "Force Delete Testsigma Agent Manually"
 metadesc: "This article discusses in Detail on how to locate Testsigma Agent Configuration file and how to stop/delete Testsigma Agent manually."
 noindex: false
-order: 11.8
-page_id: "Force Delete Testsigma Agent Manually"
+order: 11.81
+page_id: "force-delete-testsigma-agent-manually"
 warning: false
 contextual_links:
 - type: section
@@ -15,6 +15,7 @@ contextual_links:
 ---
 
 ---
+
 1. Stop Agent
 
 Once the agent is started, you can see the Testsigma Agent icon on the status bar (Mac/Linux) or System Tray (Windows). Here’s a preview on Mac:
@@ -22,14 +23,16 @@ Once the agent is started, you can see the Testsigma Agent icon on the status ba
 ![Testsigma agent icon in the status bar once the agent is started](https://docs.testsigma.com/images/force-delete/testsigma-agent-icon-once-started.png)
 
 Click on the Testsigma Agent icon to reveal the menu and click on the Quit option to stop the agent.
+
 2. Delete the Folder from which the agent was started.
+
 3. Delete Agent entry in Testsigma agents list view.
+
 4. Delete agent.properties file.
 
 
-
-
 ---
+
 ## **Location of Testsigma Agent Configuration file (agent.properties)**
 
 The Testsigma Configuration/Log files are located at the following locations depending on the Operating System used:
@@ -42,7 +45,6 @@ The Testsigma Configuration/Log files are located at the following locations dep
 
 - The %userprofile% points to the C:\Users\<username> folder where <username> is replaced by your Windows login username.
 
-- $HOME in Linux/Mac also points to the user's home folder
+- **$HOME** in Linux/Mac also points to the user's home folder
 
-
-
+---

--- a/src/pages/docs/agent/overview.md
+++ b/src/pages/docs/agent/overview.md
@@ -3,7 +3,7 @@ title: "Testsigma Agent - Overview"
 metadesc: "To execute tests locally, you need Testsigma Agent running on the machine. Learn what is Testsigma Agent, how it works, why is it useful, and other FAQs regarding it."
 noindex: false
 order: 11.1
-page_id: "Testsigma Agent - Overview"
+page_id: "testsigma-agent-overview"
 warning: false
 contextual_links:
 - type: section
@@ -18,6 +18,7 @@ contextual_links:
 Testsigma allows you to run tests on your local machines/devices and Testsigma Cloud machines/devices. For running the tests locally, you need a small Testsigma Agent (Java) utility running on the machine for test orchestration, i.e., queueing tests, running the tests, fetching the test results, etc.
 
 ---
+
 ## **Important Items on Testsigma Agent**
 - For more information on frequently asked questions regarding Testsigma Agent, refer to the [documentation on Testsigma Agent FAQ](https://testsigma.com/docs/agent/faqs/)
 

--- a/src/pages/docs/agent/pre-requisite.md
+++ b/src/pages/docs/agent/pre-requisite.md
@@ -1,9 +1,9 @@
 ---
-title: " Prerequisites for Testsigma Agent"
+title: "Prerequisites for Testsigma Agent"
 metadesc: "The pre-requisites or conditions that should be met before you can successfully install and execute Testsigma agent on your devices."
 noindex: false
 order: 11.2
-page_id: " Pre-requisites for Testsigma Agent"
+page_id: "pre-requisites-for-testsigma-agent"
 warning: false
 contextual_links:
 - type: section

--- a/src/pages/docs/agent/setup-on-windows-mac-linux.md
+++ b/src/pages/docs/agent/setup-on-windows-mac-linux.md
@@ -3,7 +3,7 @@ title: "Setting Up Testsigma Agent Locally"
 metadesc: "Learn how to install Testsigma Agent on your local machine and register it to your Testsigma Account for local inspection and test runs."
 noindex: false
 order: 11.3
-page_id: " Setting up Testsigma Agent on your local machine"
+page_id: "setting-up-testsigma-agent-on-your-local-machine"
 warning: false
 contextual_links:
 - type: section
@@ -48,6 +48,7 @@ With **Testsigma Agent** you can run tests on local machines/devices in addition
 ---
 
 ## **Steps to Download Testsigma Agent as a ZIP File**
+
 1. Navigate to **Agents** and click **Download Agent**.
 ![Agents Page](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/Navigate_To_Agents.png)
 
@@ -67,6 +68,8 @@ With **Testsigma Agent** you can run tests on local machines/devices in addition
       The home directory is recommended so as to avoid hassles of setting file permissions and ownership and also to avoid file corruption due to syncing with iCloud or Google Drive.
 
 You can either start the Testsigma agent server as a process via the command line or terminal when needed. Or, you can run the Testsigma agent server as a server. For more information, refer to the below sections to see how to start the Testsigma Agent as a process or as a service.
+
+Note: You can
 
 ---
 
@@ -114,6 +117,12 @@ Once the installation is complete, you can either run the Testsigma Agent server
 ![Reg page](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/applications/Agent_Reg_Page.png)
 
 For more information on how to register Testsigma Agent, refer to the [documentation on registering the Testsigma Agent](https://testsigma.com/docs/agent/setup-on-windows-mac-linux/#register-the-testsigma-agent).
+
+
+[[info | **NOTE**:]]
+| - You can also double-click the executable file in the installation folder to start the agent directly.
+|   ![Exe File](https://s3.amazonaws.com/static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/Agent_Exe_File_in_Folder.png)
+| - For Windows, locate **TestsigmaAgent.exe** and double-click to start the agent.
 
 ---
 

--- a/src/pages/docs/agent/soft-and-permanent-deletion-of-agents.md
+++ b/src/pages/docs/agent/soft-and-permanent-deletion-of-agents.md
@@ -2,8 +2,8 @@
 title: "Delete Agents: Soft & Permanent"
 metadesc: "This article discusses how to soft/permanently delete Testsigma agents & push them to obsolete state & restore these agents when needed | Learn how to soft/permanently delete agents"
 noindex: false
-order: 11.81
-page_id: "Agent Soft Delete"
+order: 11.82
+page_id: "agent-soft-delete"
 warning: false
 contextual_links:
 - type: section

--- a/src/pages/docs/agent/trigger-tests-locally.md
+++ b/src/pages/docs/agent/trigger-tests-locally.md
@@ -2,8 +2,8 @@
 title: "Triggering Tests on Local Devices"
 metadesc: "Execute the tests on local agents from another device using the same Testsigma account | Learn how to trigger tests on local devices from different machines"
 noindex: false
-order: 11.82
-page_id: "Trigger Tests Locally"
+order: 11.83
+page_id: "trigger-tests-locally"
 warning: false
 contextual_links:
 - type: section

--- a/src/pages/docs/agent/troubleshooting/how-to-add-max-sessions-for-agents.md
+++ b/src/pages/docs/agent/troubleshooting/how-to-add-max-sessions-for-agents.md
@@ -3,7 +3,7 @@ title: "How to Add Max Sessions for Agents?"
 metadesc: "Specify the maximum number of sessions for the local machine while setting up the local agent. This helps limit parallel executions & avoids slowing down of machine"
 noindex: false
 order: 11.94
-page_id: ""
+page_id: "how-to-add-max-sessions-for-agents"
 search_keyword: "how-to-add-max-sessions-for-agents-?"
 warning: false
 contextual_links:

--- a/src/pages/docs/agent/update-agent-manually.md
+++ b/src/pages/docs/agent/update-agent-manually.md
@@ -2,7 +2,7 @@
 title: "Update Testsigma agent manually"
 metadesc: "In case the auto-update failures of Testsigma Agent due to bad network conditions or incorrect configuration, you can update the Agent manually."
 order: 11.6
-page_id: "Update Testsigma Agent manually"
+page_id: "update-testsigma-agent-manually"
 warning: false
 contextual_links:
 - type: section

--- a/src/pages/docs/agent/update-drivers-manually.md
+++ b/src/pages/docs/agent/update-drivers-manually.md
@@ -3,7 +3,7 @@ title: "Update browser drivers for Testsigma agent manually"
 metadesc: "Learn how to update the Browser Driver files for Testsigma Agent manually if update fails, due to bad network conditions or Firewall restrictions."
 noindex: false
 order: 11.7
-page_id: "Update browser drivers for Testsigma agent manually"
+page_id: "update-bbrowser-drivers-for-testsigma-agent-manually"
 warning: false
 contextual_links:
 - type: section


### PR DESCRIPTION
Added Command-Line Arguments & Usage Guide
<img width="1707" height="920" alt="image" src="https://github.com/user-attachments/assets/4c5f41ba-f392-4cf9-b239-12862f7073ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new “Arguments Usage Details” page covering all Testsigma Agent command-line options.
  - Introduced a corresponding top-level left navigation entry.

- Documentation
  - Improved Agent setup guides with clearer notes for ZIP/executable/service starts and OS specifics.
  - Reordered and clarified steps in the force-delete guide; added emphasis and spacing for readability.
  - Standardized page identifiers and ordering across Agent docs (overview, prerequisites, soft delete, trigger locally, update agent/drivers, troubleshooting).
  - Added a new section to the Agent overview and minor formatting/punctuation fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->