### PR TITLE
Update cd.yml to use OIDC for AWS authentication

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - "main"
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   Deploy:
     runs-on: ubuntu-latest
@@ -25,6 +29,8 @@ jobs:
         run: |
           rm -rf .env
           touch .env
+          echo AWS_ROLE_ARN=${{ secrets.WEBSITE_AWS_GITHUB_OIDC_ROLE_ARN }} >> .env
+          echo AWS_DEFAULT_REGION=us-east-1 >> .env
           echo BUCKET_NAME=${{ secrets.BUCKET_NAME }} >> .env
           echo HOST_NAME=${{ secrets.HOST_NAME }} >> .env
           echo ASSET_HOST=${{ secrets.ASSET_HOST }} >> .env
@@ -39,14 +45,19 @@ jobs:
           echo TYPESENSE_API_KEY=${{ secrets.TYPESENSE_API_KEY }} >> .env
           echo TYPESENSE_SEARCH_API_KEY=${{ secrets.TYPESENSE_SEARCH_API_KEY }} >> .env
           cat .env
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.WEBSITE_AWS_GITHUB_OIDC_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: 'us-east-1'
+          audience: sts.amazonaws.com
+
       - name: Build
         run: |
           PREFIX_PATHS=true npm run build && npm run deploy
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: "us-east-1"
-          AWS_DEFAULT_OUTPUT: json
           TYPESENSE_HOST: ${{ secrets.TYPESENSE_HOST }}
           TYPESENSE_PORT: ${{ secrets.TYPESENSE_PORT }}
           TYPESENSE_PROTOCOL: ${{ secrets.TYPESENSE_PROTOCOL }}


### PR DESCRIPTION
## Summary
- Switch production CD workflow from static AWS access keys (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`) to GitHub OIDC-based authentication using `aws-actions/configure-aws-credentials@v4`
- Add `permissions` block for `id-token: write` and `contents: read`
- Add `AWS_ROLE_ARN` and `AWS_DEFAULT_REGION` to the `.env` file creation step
- Mirrors the changes already applied to `staging-cd.yml`

## Test plan
- [ ] Verify the production deploy workflow triggers correctly on push to `main`
- [ ] Confirm AWS credentials are obtained via OIDC (no static keys needed)
- [ ] Validate that build, deploy, and indexing steps complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)