### PR TITLE
Update the "Users and Role Management" doc and add the "Pause" feature to the Copilot Test Authoring docs

### DIFF
--- a/src/pages/docs/collaboration/users-roles.md
+++ b/src/pages/docs/collaboration/users-roles.md
@@ -18,8 +18,12 @@ contextual_links:
   name: "Assign Roles to Users From Project Settings"
   url: "#assign-roles-to-users-from-project-settings"
 - type: link
-  name: "Deleting Users From a Project"
-  url: "#deleting-users-from-a-project"  
+  name: "Delete Users From a Project"
+  url: "#delete-users-from-a-project" 
+- type: link
+  name: "Invite a Read Only User"
+  url: "#invite-a-read-only-user" 
+
 ---
 
 ---
@@ -29,7 +33,7 @@ When a user is added in Testsigma, they can be assigned various roles. This docu
 ---
 
 ## **Roles in Testsigma**
-Below are the four roles that can be assigned to a project member in Testsigma:
+Below are the six roles that can be assigned to a project member in Testsigma:
 
 1. **Super Administrator:** A user in a ‘Super Administrator’ role will have complete control over the Testsigma project but will be restricted from viewing Account or Billing-related information.
 
@@ -41,7 +45,7 @@ Below are the four roles that can be assigned to a project member in Testsigma:
 
 5. **Account Administrator:** A user in the role of ‘Account Administrator’ has all the rights as a Super Administrator. In addition, they will also have access to billing-related information for that particular account.
 
-
+6. **Read Only:** A user in the role of 'Read Only' will be able to view the contents of your project without making any modifications.
 
 ---
 
@@ -81,11 +85,9 @@ Below are the four roles that can be assigned to a project member in Testsigma:
 
 The invited user should receive an invitation email. They will need to join via the link sent in the email. Once they have joined they should be able to work on the project according to the role assigned to them.
 
-
-
 ---
 
-## **Deleting Users From a Project**
+## **Delete Users From a Project**
 
 
 If you're the super administrator of the project, you can delete users. 
@@ -102,6 +104,27 @@ If you're the super administrator of the project, you can delete users.
 
 Alternatively, you can also delete user from global settings by navigating to **Settings > Users**.
 
-
-
 ---
+
+## **Invite a Read Only User**
+
+1. From the left navigation bar, go to **Settings > Users**.
+   ![Users](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/read_only_user_1.png)
+
+2. On the **Users** details page, click **Add new user** in the top-right corner of the screen.
+   ![Add new User](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/read_only_user_2.png)
+
+3. In the **Add New User** dialog, enter the email address of the user in the **Email** field.
+   ![Email](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/read_only_user_3.png)
+
+4. Select the **Read Only** checkbox to assign Read Only access to the user.
+   ![Read Only](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/read_only_user_4.png)
+
+5. Click **Send Invite**.
+   ![Send Invite](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/read_only_user_5.png)
+
+A confirmation message **Invite sent successfully** appears, and the invited user is listed under the **Users** page with the status **Invited**. The user will receive an email invitation to join the workspace with Read Only access.
+
+[[info | **NOTE**:]]
+| Until the invited user accepts the invitation, their status remains Invited. You can click **Resend Invite** next to the user's name if needed.
+| ![Resend Invite](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/read_only_user_6.png)

--- a/src/pages/docs/debugging/debugging-localdevices-web.md
+++ b/src/pages/docs/debugging/debugging-localdevices-web.md
@@ -72,11 +72,11 @@ For tests that include loops, Copilot offers granular loop inspection, allowing 
 
 Common debugging actions are available globally to control execution from anywhere, and are enabled when the test is paused at a debug point or on a failure. Using the global toolbar, you can:
 
-   - **Resume Execution -** Continues the test from the next execution step. The test does not restart from the beginning.
-   - **Step Over -** Moves execution forward by executing the current test step (where execution is paused) and then pauses again at the very next test step in the same flow.
-   - **Skip Over -** Skips the current step (where the execution is paused) and pauses again at the very next step in the same flow.
-   - **Restart Execution -** The Copilot clears the current session and restarts a fresh session in order to execute the test steps from the start.
-
+   - **Resume Execution:** Continues the test from the next execution step. The test does not restart from the beginning.
+   - **Step Over:** Moves execution forward by executing the current test step (where execution is paused) and then pauses again at the very next test step in the same flow.
+   - **Skip Over:** Skips the current step (where the execution is paused) and pauses again at the very next step in the same flow.
+   - **Restart Execution:** The Copilot clears the current session and restarts a fresh session in order to execute the test steps from the start.
+   - **Pause:** Temporarily pauses the test execution at the current step, allowing it to be resumed later from the same step without restarting the test.
 ---
 
 ## **Adding Debug Points**

--- a/src/pages/docs/debugging/results-on-local-devices.md
+++ b/src/pages/docs/debugging/results-on-local-devices.md
@@ -81,6 +81,7 @@ Common debugging actions are accessible at a global level to control execution f
    - **Step Over -** Moves execution forward by skipping the current debug point and executing the next step. The test then pauses at the following step.
    - **Skip Over -** Skips the step where the debug point is placed without executing it and pauses execution immediately.
    - **Restart Execution -** Restarts the test case execution from the first step. This can only be used when the test execution is paused.
+   - **Pause:** Temporarily pauses the test execution at the current step, allowing it to be resumed later from the same step without restarting the test.
 
 ---
 


### PR DESCRIPTION
Update the "Users and Role Management" doc and add the "Pause" feature to the Copilot Test Authoring docs as per the ticket https://testsigma.atlassian.net/browse/DOC-2083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the "Read Only" user role and invitation workflow.
  * Documented the new "Pause" action in the Global Debug Toolbar to temporarily stop test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->