### PR TITLE
Clarify WDA/provisioning profile required only for local executions 

### DIFF
--- a/src/pages/docs/configuration/generate-wda-file.md
+++ b/src/pages/docs/configuration/generate-wda-file.md
@@ -21,6 +21,9 @@ contextual_links:
 
 WebDriverAgent (WDA) plays an important role in automating iOS tests. It bridges the code we write for testing and the actual iOS app, which helps us control the app, test how it behaves, and make sure it works correctly. This article discusses the steps and prerequisites for creating WDA files.
 
+[[info | **NOTE**:]]
+| Creating a provisioning profile and WDA file is required **only for local agent–based executions**. If you are running tests exclusively on cloud devices from Testsigma Lab, you do **not** need to create a WDA file or provisioning profile.
+
 ---
 
 > <p id="prerequisites">Prerequisites</p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying when provisioning profiles and WDA files are needed.
  * Explained that these steps are only required for local agent-based runs, not for tests executed exclusively on cloud devices in Testsigma Lab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->