### PR TITLE
Add Edge capability key and profile notes to profile setup guide

### DIFF
--- a/src/pages/docs/package-manager/profile-setup-guide.md
+++ b/src/pages/docs/package-manager/profile-setup-guide.md
@@ -65,15 +65,19 @@ To set this up:
 3. Copy the value in the **Profile Path** row.
    ![profile path](https://s3.amazonaws.com/static-docs.testsigma.com/new/projects/applications/Profile_Path_for_Execution.png)
 
-4. In the test confiuration settings, add the following **Desired Capabilities**:
+4. In the test configuration settings, add the following **Desired Capabilities**. The key depends on your browser, while the value stays the same:
 
-   | Key | Data type | Value |
-   | :-- | :-- | :-- |
-   | **goog:chromeOptions** | String | **{"args":["--user-data-dir=&lt;Profile Path&gt;"]}** |
+   | Browser | Key | Data type | Value |
+   | :-- | :-- | :-- | :-- |
+   | **Chrome** | **goog:chromeOptions** | String | **{"args":["--user-data-dir=&lt;Profile Path&gt;"]}** |
+   | **Microsoft Edge** | **MsOptions** | String | **{"args":["--user-data-dir=&lt;Profile Path&gt;"]}** |
 
    Replace **<Profile Path>** with the path you copied in **step 3**.
 
 [[info | NOTE:]]
-| This capability is confirmed for Chrome. If you're using Edge, the profile path lookup works the same way via **edge://version**. 
+| The browser must be **fully closed** before launching the session. A profile can't be used by two browser instances at once, including background or tray processes with no visible window. Otherwise, the session fails to start with a **"user data directory is already in use"** error.
+
+[[info | NOTE:]]
+| To use a **non-default** profile instead of your default one, pass **--profile-directory=&lt;folder name&gt;** alongside **--user-data-dir** (for example, **Profile 1**). The default profile works with just the **--user-data-dir** argument as documented above.
 
 ---


### PR DESCRIPTION
## Summary

Updates **point 4** of the [Profile Setup Guide](https://website.testsigma.com/docs/package-manager/profile-setup-guide/#your-own-browser-profile) based on review feedback from the docs review thread.

## Changes

- **Edge capability key added** — `goog:chromeOptions` is Chrome-only, so the Desired Capabilities table now lists the key per browser:
  - **Chrome** → `goog:chromeOptions`
  - **Microsoft Edge** → `MsOptions`
  - (value stays the same: `{"args":["--user-data-dir=<Profile Path>"]}`)
- **New note** — the browser must be **fully closed** before launching the session, otherwise it fails with a "user data directory is already in use" error (including background/tray processes).
- **New note** — how to use a **non-default** profile via `--profile-directory=<folder name>` alongside `--user-data-dir`.
- Fixed a typo ("confiuration" → "configuration").

The previous Chrome/Edge note was replaced since Edge is now explicitly covered in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmWxbbRxRfiKn4T9Q3FZeg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated browser profile setup guidance with Desired Capabilities examples for Chrome and Microsoft Edge.
  * Added instructions for using non-default browser profiles.
  * Clarified that browser profiles must be fully closed before starting a session to avoid errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->