### PR TITLE
reverting copilot docs content

### DIFF
--- a/src/pages/docs/copilot/introduction.md
+++ b/src/pages/docs/copilot/introduction.md
@@ -24,8 +24,6 @@ contextual_links:
 
 Testsigma's Copilot is an AI-powered test-authoring and debugging tool that lets you iterate over the test case by generating, editing, and executing test steps in a single live session. You can build, run, and modify a test case during the session without exiting it.
 
-A Copilot session runs on the Testsigma Lab (Cloud) or on Local Devices. The Testsigma Lab is a cloud machine that Testsigma hosts. Select it to start a session without installing anything. Local Devices is your own machine, and it needs the Testsigma Terminal. Select it when the cloud can't reach the app you're testing.
-
 As you work, Copilot analyzes the application screen and generates relevant test steps based on the actions you perform. Each generated step can be executed immediately, allowing you to verify whether it works before moving to the next step. This makes the test creation process more interactive and reduces the need to switch between authoring, execution, and debugging repeatedly.
 
 

--- a/src/pages/docs/copilot/key-capabilities.md
+++ b/src/pages/docs/copilot/key-capabilities.md
@@ -14,12 +14,8 @@ warning: false
 
 Copilot brings together a set of capabilities that make test authoring, debugging, and execution faster and more reliable. The table below provides a quick overview of each capability, its functions, and the value it delivers.
 
-<br>
-
 | Capability | What it does | Why it helps |
 |---|---|---|
-| Cloud execution | Runs a Copilot session on the **Testsigma Lab**, a cloud machine that Testsigma hosts. | Lets you start a session without any local setup. |
-| Local execution | Runs a Copilot session on your **Local Devices** through the **Testsigma Terminal**. | Lets you test an app that the cloud can't reach. |
 | Record Steps | Captures interactions from a live browser and automatically converts them into executable test steps. | Combines step creation and execution by automatically executing and validating recorded steps during the session. |
 | Debug Points | Pause the test at any chosen step. They can be added or removed before or during a run. While paused, the application can be inspected and upcoming steps adjusted before continuing. | Gives you precise control over where execution halts, so you can investigate issues exactly where they happen, without restarting the test. |
 | Copilot Debug Toolbar | A global debug toolbar that provides execution controls such as Pause, Resume, Skip Over, Step Over, and Restart to manage test execution during an active session. | Keeps every action you need to reach within, so you can stay focused on the test instead of searching for controls. |

--- a/src/pages/docs/copilot/launch-copilot.md
+++ b/src/pages/docs/copilot/launch-copilot.md
@@ -1,7 +1,7 @@
 ---
 title: "Launch Copilot"
 pagetitle: "Launch Copilot"
-metadesc: "Learn to launch Copilot on the Testsigma Cloud Lab or Local Devices from within a test case, and use debug points and execution controls to streamline testing."
+metadesc: "Learn to launch Copilot within a test case and use debug points and execution controls to streamline testing."
 noindex: false
 order: 11.13
 page_id: "launch-copilot"
@@ -29,7 +29,7 @@ In Testsigma, you can launch Copilot directly from a test case to work with your
 >
 > Before you begin, ensure that:
 >    - You have created a test case.
->    - If you plan to run Copilot on **Local Devices**, you have installed and configured the **Testsigma Terminal**.
+>    - You have installed and configured the **Testsigma Terminal**.
 
 ---
 
@@ -44,33 +44,19 @@ In Testsigma, you can launch Copilot directly from a test case to work with your
 3. In the test case details page, click **Copilot** in the **Action Panel**.
    ![Copilot](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/launch_copilot_2.png)
 
-4. In the **Copilot** overlay, select the **Test Lab** to run the session on: **Testsigma Lab** (Cloud) or **Local Devices**.
-   ![Copilot](https://s3.amazonaws.com/static-docs.testsigma.com/new/projects/applications/Copilot_Cloud.png)
-
-   - **Testsigma Lab** (Cloud): Select **Testsigma Lab** to launch a session on Cloud, which runs on Chrome for Testing on a virtual machine. This doesn't require **Terminal** setup, unlike local executions.
-
-   - **Local Devices**: Select this option to run the session on your local machine. Make sure the **Testsigma Terminal** up and running.
-
-[[info | **NOTE**:]]
-| - A session on the **Testsigma Lab** occupies one cloud parallel for its duration, and the parallel is released only when the session ends. If no cloud parallel is available, you cannot launch the session.
-| - Copilot sessions on the Testsigma Lab always use Chrome for Testing. Currently, OS and resolution aren't configurable.
-| - A cloud session is single-active. If you try to open the same session elsewhere while it's still active, Testsigma refuses the request.
-| - If a cloud session sits idle, a countdown dialog appears warning you before it expires. If you don't respond in time, the session ends and the cloud machine is released.
-| - Runs performed through a cloud session are recorded as **Dry Run** on the parallel usage.
-
-1. In the **Copilot** overlay, click the dropdown in the **Set Initial Debug Point** field and select the step at which you want execution to pause automatically.
+4. In the **Copilot** overlay, click the dropdown in the **Set Initial Debug Point** field and select the step at which you want execution to pause automatically.
    ![Set Initial Debug point](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/launch_copilot_3.png)
 
-2. If needed, click the dropdown in the **Execute from Step** field and select the step from which you want execution to begin, skipping all prior steps.
+5. If needed, click the dropdown in the **Execute from Step** field and select the step from which you want execution to begin, skipping all prior steps.
    ![Execute from Step](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/launch_copilot_4.png)
 
 [[info | **NOTE**:]]
 | Make sure your application under test is on the screen that corresponds to the selected step before using this option.
 
-7. Configure **Environment**, **Additional Settings**, and **Desired Capabilities**, if needed.
+6. Configure **Environment**, **Additional Settings**, and **Desired Capabilities**, if needed.
    ![Additional settings](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/launch_copilot_5.png)
 
-8. Click **Launch** and wait for Copilot to start a session.
+7. Click **Launch** and wait for Copilot to start a session.
    ![Launch](https://s3.amazonaws.com/website-static-docs.testsigma.com/new_images/projects/Updated_Doc_Images/launch_copilot_6.png)
 
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Copilot guidance to remove references to session environments, cloud execution, and local execution.
  - Clarified that Testsigma Terminal installation and configuration is required before launching Copilot.
  - Simplified launch instructions by removing test lab or device selection steps.
  - Updated the capabilities list to highlight recording steps, debugging tools, execution from a step, and in-session step management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->