### PR TITLE
updated browser-profiles & export-test-reports

### DIFF
--- a/src/left-nav-title.json
+++ b/src/left-nav-title.json
@@ -767,7 +767,7 @@
   "byok": {"/docs/atto/generative-ai/byok/": "BYOK"},
   "generate-allure-report": {"/docs/reports/runs/generate-allure-report/": "Custom Allure Reports Generation"},
   "generate-junit-report": {"/docs/reports/runs/generate-junit-report/": "Custom JUnit Report Generation"},
-  "profile-setup-guide": {"/docs/package-manager/profile-setup-guide/": "Browser Profile for Copilot"},
+  "profile-setup-guide": {"/docs/copilot/profile-setup-guide/": "Browser Profile for Copilot"},
   "security-and-access-requirements": {"/docs/package-manager/security-and-access-requirements/": "Security & Access Requirements"},
   "it-admin": {"/docs/integrations/it-admin/": "IT Admin"},
   "patchmypc-integration-with-testsigma": {"/docs/integrations/it-admin/patchmypc-integration-with-testsigma/": "PatchMyPC"},

--- a/src/pages/docs/api/export-test-reports.md
+++ b/src/pages/docs/api/export-test-reports.md
@@ -89,11 +89,11 @@ This endpoint generates a report for an entire test plan run.
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/execution\_result/<RUN\_ID>?format=xlsx|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/execution_result/{RUN_ID}?format=xlsx|
+|**Authorization**|Bearer {API_Token}|
 |**Response Body**|{<br>&emsp;"status": "IN\_PROGRESS"<br>}|
 
-**<RUN\_ID>** is the ID of the test plan run you want to export.
+**{RUN_ID}** is the ID of the test plan run you want to export.
 
 ### **Export a Test Machine Report**
 
@@ -101,10 +101,10 @@ This endpoint generates a report for a single test machine within a run.
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/environment\_result/<MACHINE\_RESULT\_ID>?format=xlsx|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/environment_result/{MACHINE_RESULT_ID}?format=xlsx|
+|**Authorization**|Bearer {API_Token}|
 
-**<MACHINE\_RESULT\_ID>** is the ID of the test machine result you want to export.
+**{MACHINE\_RESULT\_ID}** is the ID of the test machine result you want to export.
 
 ### **Export a Test Suite Report**
 
@@ -112,10 +112,10 @@ This endpoint generates a report for a single test suite within a run.
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/suite\_result/<SUITE\_RESULT\_ID>?format=xlsx|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/suite_result/{SUITE_RESULT_ID}?format=xlsx|
+|**Authorization**|Bearer {API_Token}|
 
-**<SUITE\_RESULT\_ID>** is the ID of the test suite result you want to export.
+**{SUITE\_RESULT\_ID}** is the ID of the test suite result you want to export.
 
 ### **Export a Test Case Report**
 
@@ -123,10 +123,10 @@ This endpoint generates a report for a single test case within a run.
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/case\_result/<CASE\_RESULT\_ID>?format=xlsx|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/case_result/{CASE_RESULT_ID}?format=xlsx|
+|**Authorization**|Bearer {API_Token}|
 
-**<CASE\_RESULT\_ID>** is the ID of the test case result you want to export.
+**{CASE\_RESULT\_ID}** is the ID of the test case result you want to export.
 
 ### **Check Report Status**
 
@@ -134,8 +134,8 @@ Send the original export request again to check progress. Once generation succee
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/execution\_result/<RUN\_ID>?format=xlsx|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/execution_result/{RUN_ID}?format=xlsx|
+|**Authorization**|Bearer {API_Token}|
 |**Response Body**|{<br>&emsp;"status": "SUCCESS",<br>&emsp;"reportId": 4821,<br>&emsp;"url": "https://app.testsigma.com/api/v1/reports/download/4821"<br>}|
 
 [[info | NOTE:]]
@@ -147,8 +147,8 @@ This endpoint generates a PDF report with the screenshots and resolution you spe
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/execution\_result/<RUN\_ID>?format=pdf&screenshot=FAILED\_STEPS&visualScreenshot=NONE&resolution=LOW|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/execution_result/{RUN_ID}?format=pdf&screenshot=FAILED\_STEPS&visualScreenshot=NONE&resolution=LOW|
+|**Authorization**|Bearer {API_Token}|
 
 [[info | NOTE:]]
 | Use 'LOW' resolution to shorten report generation time. Reports at 'HIGH' resolution take longer to generate and download.
@@ -159,13 +159,13 @@ This endpoint returns the generated report artifact. It redirects to a short-liv
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/download/<REPORT\_ID>|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/download/{REPORT_ID}|
+|**Authorization**|Bearer {API_Token}|
 
-**<REPORT\_ID>** is the **reportId** returned in the status response.
+**{REPORT_ID}** is the **reportId** returned in the status response.
 
 [[info | NOTE:]]
-| The download link expires. Follow the redirect within the same request rather than storing the link for later use. Each call to this endpoint generates a fresh link, so the same **<REPORT\_ID>** stays valid for repeat downloads.
+| The download link expires. Follow the redirect within the same request rather than storing the link for later use. Each call to this endpoint generates a fresh link, so the same **{REPORT_ID}** stays valid for repeat downloads.
 
 ### **Get JUnit Report (Deprecated)**
 
@@ -173,8 +173,8 @@ This endpoint returns the JUnit XML report for a test plan run. It is deprecated
 
 |**Request Type**|**GET**|
 |---|---|
-|**Endpoint**|https://app.testsigma.com/api/v1/reports/junit/<RUN\_ID>|
-|**Authorization**|Bearer <API\_Token>|
+|**Endpoint**|https://app.testsigma.com/api/v1/reports/junit/{RUN_ID}|
+|**Authorization**|Bearer {API_Token}|
 
 ---
 
@@ -225,7 +225,7 @@ For data-driven test cases, the **testCase** element carries the test data used 
 
 ## **Migrate from the JUnit Endpoint**
 
-Move pipelines from **/api/v1/reports/junit/<RUN\_ID>** to **/api/v1/reports/execution\_result/<RUN\_ID>** before the sunset date in the response header. The JUnit output itself is unchanged until then.
+Move pipelines from **/api/v1/reports/junit/{RUN_ID}** to **/api/v1/reports/execution\_result/{RUN\_ID}** before the sunset date in the response header. The JUnit output itself is unchanged until then.
 
 [[info | NOTE:]]
 | The Testsigma XML report replaces the JUnit endpoint but uses a different schema. If your pipeline publishes results with a JUnit parser, such as the **Publish Test Results** task in Azure DevOps, keep using the JUnit endpoint until you update that step.

--- a/src/pages/docs/copilot/profile-setup-guide.md
+++ b/src/pages/docs/copilot/profile-setup-guide.md
@@ -3,7 +3,7 @@ title: "Setup Browser Profile for Copilot Recording"
 page_title: "Setup Browser Profile for Copilot Recording | Testsigma"
 metadesc: "Configure how Testsigma loads its recorder extension into your browser for Copilot recording sessions, using Automatic, Managed, or Your Own Browser Profile mode."
 noindex: false
-order: 21.2
+order: 11.1601
 page_id: "setup-browser-profile-for-copilot-recording"
 warning: false
 contextual_links:
@@ -22,8 +22,11 @@ contextual_links:
   name: "Your own browser profile"
   url: "#your-own-browser-profile"
 - type: link
-  name: "Quick Reference"
-  url: "#quick-reference"
+  name: "Default User-Data Folder Restriction"
+  url: "#default-user-data-folder-restriction"
+- type: link
+  name: "Path Tokens in Desired Capabilities"
+  url: "#path-tokens-in-desired-capabilities"
 ---
 
 ---
@@ -69,7 +72,7 @@ Sessions run in a browser profile your team manages; the recorder extension must
 
 **To set this up:**
 
-1. Create the profile folder outside the default user-data folders listed above, and outside the Testsigma data directory.
+1. Create the profile folder outside the default user-data folders listed below, and outside the Testsigma data directory.
 
 2. Grant Testsigma read and write access to that folder.
 
@@ -82,10 +85,17 @@ Sessions run in a browser profile your team manages; the recorder extension must
 
    Replace **&lt;Profile Path&gt;** with the path of the folder you created in **step 1**.
 
+   Writing that path literally bakes in a machine-specific username (for example, **C:\Users\username\AppData\...**), so the capability only works on the one agent it was written for. If this configuration needs to run on more than one agent, replace the literal path with a path token instead, such as **${TS\_DATA\_DIR}** or **${TS\_USER\_HOME}**. Testsigma resolves these to the correct machine-specific path on whichever agent the test runs on, so the same capability value works everywhere:
+
+   **{"args": ["--user-data-dir=${TS\_DATA\_DIR}/browser-profiles/custom/testprofile"]}**
+
+   Path tokens (see **Path Tokens in Desired Capabilities** below) only resolve for Hybrid executions (local machine or Docker). On Testsigma Lab/TSLab/Apex and third-party cloud labs (BrowserStack, Sauce Labs, LambdaTest, Kobiton), or a Hybrid agent pointed at an external Selenium grid, tokens are not resolved and the value is passed through exactly as written — use a literal path for those execution types instead.
+
 4. Install the recorder extension in that profile, either from the Chrome Web Store or through your IT extension policy.
 
+---
 
-### **Default User-Data Folder Restriction**
+## **Default User-Data Folder Restriction**
 
 A profile used for automation cannot live inside the browser's default user-data folder. This restriction comes from Chrome and Edge, not from Testsigma. Anything placed inside these directories is not accessible to automation, and Testsigma cannot launch it.
 
@@ -97,9 +107,28 @@ A profile used for automation cannot live inside the browser's default user-data
 | **Microsoft Edge** | **%LOCALAPPDATA%\Microsoft\Edge\User Data** | **~/Library/Application Support/Microsoft Edge** | **~/.config/microsoft-edge** |
 
 [[info | NOTE:]]
-| The browser must be **fully closed** before launching the session. A profile can't be used by two browser instances at once, including background or tray processes with no visible window. Otherwise, the session fails to start with a **"user data directory is already in use"** error.
+| - The browser must be **fully closed** before launching the session. A profile can't be used by two browser instances at once, including background or tray processes with no visible window. Otherwise, the session fails to start with a **"user data directory is already in use"** error.
+| - To use a named profile inside that folder rather than the default one, pass **--profile-directory=&lt;folder name&gt;** alongside **--user-data-dir** (for example, **Profile 1**). The default profile works with just the **--user-data-dir** argument as documented above.
+
+---
+
+## **Path Tokens in Desired Capabilities**
+
+A literal path like **--user-data-dir=C:\Users\username\AppData\Roaming\...** only works on one machine. Path tokens let the agent fill in the machine-specific part automatically, so one config works on every agent:
+
+**--user-data-dir=${TS\_DATA\_DIR}/profiles/**
+
+| Token | Resolves to |
+| :-- | :-- |
+| **${TS\_DATA\_DIR}** | The Testsigma agent's data directory (honors a custom **ENV\_TS\_DATA\_DIR** if IT set one at install) |
+| **${TS\_USER\_HOME}** | The home directory of the OS account running the agent |
+
+These are the recommended, portable tokens — they work the same on Windows, macOS, and Linux. Native OS aliases (**%APPDATA%**, **$HOME**, **~/**, etc.) also work but only resolve on their own platform.
 
 [[info | NOTE:]]
-| To use a named profile inside that folder rather than the default one, pass **--profile-directory=&lt;folder name&gt;** alongside **--user-data-dir** (for example, **Profile 1**). The default profile works with just the **--user-data-dir** argument as documented above.
+| Tokens apply inside any string value (args, prefs, extensions, binary) in Chrome, Edge, or Firefox capabilities, but only when the browser runs locally on an agent host (Hybrid, local machine, or Docker). They do not resolve on Testsigma Lab/TSLab/Apex, third-party cloud labs (BrowserStack, Sauce Labs, LambdaTest, Kobiton), a Private Grid, or a Hybrid agent pointed at an external Selenium grid — use a literal path there instead.
+
+[[info | NOTE:]]
+| An unresolvable token is left exactly as written, never blanked out, and Testsigma logs a warning — a visibly wrong path is safer than silently falling back to the real desktop profile.
 
 ---

--- a/src/redirects.json
+++ b/src/redirects.json
@@ -1,5 +1,9 @@
 [
   {
+    "from": "/docs/package-manager/profile-setup-guide/",
+    "to": "/docs/copilot/profile-setup-guide/"
+  },
+  {
     "from": "/docs/addons",
     "to": "/docs/addons/overview"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the profile setup guide location and added a redirect from the previous URL.
  * Expanded custom browser profile guidance, including supported paths, portable path tokens, profile restrictions, and warning behavior.
  * Clarified API documentation examples by standardizing placeholder formatting across export and report-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->